### PR TITLE
throw unchecked Exceptions, User create/delete

### DIFF
--- a/src/main/java/org/aarboard/nextcloud/api/NextcloudConnector.java
+++ b/src/main/java/org/aarboard/nextcloud/api/NextcloudConnector.java
@@ -16,12 +16,12 @@
  */
 package org.aarboard.nextcloud.api;
 
-import java.io.File;
-import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
 
+import org.aarboard.nextcloud.api.exception.NextcloudApiException;
 import org.aarboard.nextcloud.api.filesharing.FilesharingConnector;
 import org.aarboard.nextcloud.api.filesharing.Share;
 import org.aarboard.nextcloud.api.filesharing.SharePermissions;
@@ -43,34 +43,46 @@ public class NextcloudConnector {
         _serverConfig= new ServerConfig(serverName, useHTTPS, port, userName, password);
     }
     
-    public boolean createGroup(String groupId) throws Exception    
+    public boolean createUser(String userId, String password)
+    {
+        ProvisionConnector pc= new ProvisionConnector(_serverConfig);
+        return pc.createUser(userId, password);
+    }
+
+    public boolean deleteUser(String userId)
+    {
+        ProvisionConnector pc= new ProvisionConnector(_serverConfig);
+        return pc.deleteUser(userId);
+    }
+
+    public boolean createGroup(String groupId)
     {
         ProvisionConnector pc= new ProvisionConnector(_serverConfig);
         return pc.createGroup(groupId);
     }
     
-    public Collection<User> getUsers() throws Exception
+    public Collection<User> getUsers()
     {
         ProvisionConnector pc= new ProvisionConnector(_serverConfig);
         return pc.getUsers();
     }
     
     public Collection<User> getUsers(
-            String search, int limit, int offset) throws Exception
+            String search, int limit, int offset)
     {
         ProvisionConnector pc= new ProvisionConnector(_serverConfig);
         return pc.getUsers(search, limit, offset);
     }
     
     
-    public boolean deleteGroup(String groupId) throws Exception
+    public boolean deleteGroup(String groupId)
     {
         ProvisionConnector pc= new ProvisionConnector(_serverConfig);
         return pc.deleteGroup(groupId);
     }
 
     
-    public Collection<Group> getGroups() throws Exception
+    public Collection<Group> getGroups()
     {
         ProvisionConnector pc= new ProvisionConnector(_serverConfig);
         return pc.getGroups();
@@ -84,31 +96,31 @@ public class NextcloudConnector {
      * @param offset pass -1 for no offset
      * @return 
      */
-    public Collection<Group> getGroups(String search, int limit, int offset) throws Exception
+    public Collection<Group> getGroups(String search, int limit, int offset)
     {
         ProvisionConnector pc= new ProvisionConnector(_serverConfig);
         return pc.getGroups(search, limit, offset);
     }
 
-    public List<String> getFolders(String path) throws Exception
+    public List<String> getFolders(String path)
     {
         Folders fc= new Folders(_serverConfig);
         return fc.getFolders(path);
     }
     
-    public boolean folderExists(String path)  throws Exception
+    public boolean folderExists(String path)
     {
         Folders fc= new Folders(_serverConfig);
         return fc.exists(path);
     }
 
-    public void createFolder(String path) throws Exception
+    public void createFolder(String path)
     {
         Folders fc= new Folders(_serverConfig);
         fc.createFolder(path);
     }
 
-    public void deleteFolder(String path) throws Exception
+    public void deleteFolder(String path)
     {
         Folders fc= new Folders(_serverConfig);
         fc.deleteFolder(path);
@@ -131,13 +143,13 @@ public class NextcloudConnector {
             String shareWithUserOrGroupId,
             Boolean publicUpload,
             String password,
-            SharePermissions permissions) throws Exception
+            SharePermissions permissions)
     {
         FilesharingConnector fc= new FilesharingConnector(_serverConfig);
         return fc.doShare(path, shareType, shareWithUserOrGroupId, publicUpload, password, permissions);
     }
     
-    public Collection<Share> getShares() throws Exception
+    public Collection<Share> getShares()
     {
         FilesharingConnector fc= new FilesharingConnector(_serverConfig);
         return fc.getShares();
@@ -149,16 +161,20 @@ public class NextcloudConnector {
      * @param remotePath           path where the file should be uploaded to
      * @throws Exception
      */
-    public void uploadFile( InputStream fileInputStream, String remotePath) throws Exception
+    public void uploadFile(InputStream fileInputStream, String remotePath)
     {
- 		String password = _serverConfig.getPassword();
- 		String username = _serverConfig.getUserName();
- 		String host = _serverConfig.getServerName();
- 		
- 		Sardine sardine = SardineFactory.begin(username, password);
- 		sardine.enablePreemptiveAuthentication(host);
+         String password = _serverConfig.getPassword();
+         String username = _serverConfig.getUserName();
+         String host = _serverConfig.getServerName();
 
- 		sardine.put(remotePath, fileInputStream);
+         Sardine sardine = SardineFactory.begin(username, password);
+         sardine.enablePreemptiveAuthentication(host);
+
+         try {
+            sardine.put(remotePath, fileInputStream);
+        } catch (IOException e) {
+            throw new NextcloudApiException(e);
+        }
     }
 
     /**
@@ -170,7 +186,7 @@ public class NextcloudConnector {
      * @return 
      * @throws java.lang.Exception 
      */
-    public Collection<Share> getShares(String path, boolean reShares, boolean subShares) throws Exception
+    public Collection<Share> getShares(String path, boolean reShares, boolean subShares)
     {
         FilesharingConnector fc= new FilesharingConnector(_serverConfig);
         return fc.getShares(path, reShares, subShares);
@@ -183,7 +199,7 @@ public class NextcloudConnector {
      * @return 
      * @throws java.lang.Exception 
      */
-    public Share getShareInfo(int shareId) throws Exception
+    public Share getShareInfo(int shareId)
     {
         FilesharingConnector fc= new FilesharingConnector(_serverConfig);
         return fc.getShareInfo(shareId);

--- a/src/main/java/org/aarboard/nextcloud/api/exception/NextcloudApiException.java
+++ b/src/main/java/org/aarboard/nextcloud/api/exception/NextcloudApiException.java
@@ -1,0 +1,9 @@
+package org.aarboard.nextcloud.api.exception;
+
+public class NextcloudApiException extends RuntimeException {
+    private static final long serialVersionUID = 8088239559973590632L;
+
+    public NextcloudApiException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/aarboard/nextcloud/api/provisioning/ProvisionConnector.java
+++ b/src/main/java/org/aarboard/nextcloud/api/provisioning/ProvisionConnector.java
@@ -16,38 +16,17 @@
  */
 package org.aarboard.nextcloud.api.provisioning;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+
 import org.aarboard.nextcloud.api.ServerConfig;
+import org.aarboard.nextcloud.api.utils.ConnectorCommon;
 import org.aarboard.nextcloud.api.utils.XMLAnswer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpHost;
-import org.apache.http.HttpStatus;
-import org.apache.http.HttpVersion;
 import org.apache.http.NameValuePair;
-import org.apache.http.StatusLine;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.AuthCache;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.impl.auth.BasicScheme;
-import org.apache.http.impl.client.BasicAuthCache;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.util.EntityUtils;
 
 /**
  *
@@ -60,25 +39,52 @@ public class ProvisionConnector
 {
     private final static Log LOG = LogFactory.getLog(ProvisionConnector.class);
 
-    private final static int   NC_OK= 100; // Nexclout OK message
+    private final static int   NC_OK= 100; // Nextcloud OK message
     
     private final static String ROOT_PART= "ocs/v1.php/cloud/";
     private final static String USERS_PART= ROOT_PART+"users";
     private final static String GROUPS_PART= ROOT_PART+"groups";
 
-    private final ServerConfig _serverConfig;
+    private final ConnectorCommon connectorCommon;
 
     public ProvisionConnector(ServerConfig serverConfig) {
-        this._serverConfig = serverConfig;
+        this.connectorCommon = new ConnectorCommon(serverConfig);
     }
-    
+
+    public boolean createUser(String userId, String password)
+    {
+        List<NameValuePair> postParams= new LinkedList<>();
+        postParams.add(new BasicNameValuePair("userid", userId));
+        postParams.add(new BasicNameValuePair("password", password));
+        String postAnswer= connectorCommon.executePost(USERS_PART, postParams);
+        if (postAnswer != null)
+        {
+            LOG.debug("Create user answer");
+        }
+        XMLAnswer xa= new XMLAnswer();
+        xa.parseAnswer(postAnswer);
+        return xa.getStatusCode() == NC_OK;
+    }
+
+    public boolean deleteUser(String userId)
+    {
+        String postAnswer= connectorCommon.executeDelete(USERS_PART, userId);
+        if (postAnswer != null)
+        {
+            LOG.debug(postAnswer);
+        }
+        XMLAnswer xa= new XMLAnswer();
+        xa.parseAnswer(postAnswer);
+        return xa.getStatusCode() == NC_OK;
+    }
+
     /**
      * Return all users of this instance
      * 
      * @return 
      * @throws java.lang.Exception 
      */
-    public Collection<User> getUsers() throws Exception
+    public Collection<User> getUsers()
     {
         return getUsers(null, -1, -1);
     }
@@ -93,7 +99,7 @@ public class ProvisionConnector
      * @throws java.lang.Exception 
      */
     public Collection<User> getUsers(
-            String search, int limit, int offset) throws Exception
+            String search, int limit, int offset)
     {
         List<NameValuePair> queryParams= new LinkedList<>();
         if (limit != -1)
@@ -108,7 +114,7 @@ public class ProvisionConnector
         {
             queryParams.add(new BasicNameValuePair("search", search));
         }
-        String queryAnswer= executeGet(USERS_PART, queryParams);
+        String queryAnswer= connectorCommon.executeGet(USERS_PART, queryParams);
         if (queryAnswer != null)
         {
             LOG.debug(queryAnswer);
@@ -122,11 +128,11 @@ public class ProvisionConnector
         return null;
     }
     
-    public boolean createGroup(String groupId) throws Exception
+    public boolean createGroup(String groupId)
     {
         List<NameValuePair> postParams= new LinkedList<>();
         postParams.add(new BasicNameValuePair("groupid", groupId));
-        String postAnswer= executePost(GROUPS_PART, postParams);
+        String postAnswer= connectorCommon.executePost(GROUPS_PART, postParams);
         if (postAnswer != null)
         {
             LOG.debug("Create group answer");
@@ -136,9 +142,9 @@ public class ProvisionConnector
         return xa.getStatusCode() == NC_OK;
     }
 
-    public boolean deleteGroup(String groupId) throws Exception
+    public boolean deleteGroup(String groupId)
     {
-        String postAnswer= executeDelete(GROUPS_PART, groupId);
+        String postAnswer= connectorCommon.executeDelete(GROUPS_PART, groupId);
         if (postAnswer != null)
         {
             LOG.debug(postAnswer);
@@ -149,7 +155,7 @@ public class ProvisionConnector
     }
 
     
-    public Collection<Group> getGroups() throws Exception
+    public Collection<Group> getGroups()
     {
         return getGroups(null, -1, -1);
     }
@@ -162,7 +168,7 @@ public class ProvisionConnector
      * @param offset pass -1 for no offset
      * @return 
      */
-    public Collection<Group> getGroups(String search, int limit, int offset) throws Exception
+    public Collection<Group> getGroups(String search, int limit, int offset)
     {
         List<NameValuePair> queryParams= new LinkedList<>();
         if (limit != -1)
@@ -178,7 +184,7 @@ public class ProvisionConnector
             queryParams.add(new BasicNameValuePair("search", search));
         }
 
-        String queryAnswer= executeGet(GROUPS_PART, queryParams);
+        String queryAnswer= connectorCommon.executeGet(GROUPS_PART, queryParams);
         if (queryAnswer != null)
         {
             LOG.debug(queryAnswer);
@@ -190,155 +196,5 @@ public class ProvisionConnector
             return xa.getGroups();
         }
         return null;
-    }
-
-    protected String executeGet(String part, List<NameValuePair> queryParams) throws Exception
-    {
-        CloseableHttpClient httpclient = HttpClients.createDefault();
-        HttpHost targetHost = new HttpHost(_serverConfig.getServerName(), _serverConfig.getPort(), _serverConfig.isUseHTTPS() ? "https" : "http");
-        AuthCache authCache = new BasicAuthCache();
-        authCache.put(targetHost, new BasicScheme());
-        
-        CredentialsProvider credsProvider = new BasicCredentialsProvider();
-        UsernamePasswordCredentials credentials
-         = new UsernamePasswordCredentials(_serverConfig.getUserName(), _serverConfig.getPassword());
-        credsProvider.setCredentials(AuthScope.ANY, credentials);
-
-        // Add AuthCache to the execution context
-        final HttpClientContext context = HttpClientContext.create();
-        context.setCredentialsProvider(credsProvider);
-        context.setAuthCache(authCache);
-
-        URI url= buildUrl(part, queryParams);
-        
-        HttpGet httpget = new HttpGet(url.toString());
-        httpget.addHeader("OCS-APIRequest", "true");
-        httpget.addHeader("Content-Type", "application/x-www-form-urlencoded");
-        httpget.setProtocolVersion(HttpVersion.HTTP_1_1);
-
-        CloseableHttpResponse response = httpclient.execute(httpget, context);
-        try {
-            StatusLine statusLine= response.getStatusLine();
-            if (statusLine.getStatusCode() == HttpStatus.SC_OK)
-            {
-                HttpEntity entity = response.getEntity();
-                if (entity != null) {
-                    //long len = entity.getContentLength();
-                    return EntityUtils.toString(entity);
-                }                
-            }
-            else
-            {
-                return null;
-            }
-        } finally {
-            response.close();
-        }
-        return null;
-    }
-
-    protected String executePost(String part, List<NameValuePair> postParams) throws Exception
-    {
-        CloseableHttpClient httpclient = HttpClients.createDefault();
-        HttpHost targetHost = new HttpHost(_serverConfig.getServerName(), _serverConfig.getPort(), _serverConfig.isUseHTTPS()  ? "https" : "http");
-        AuthCache authCache = new BasicAuthCache();
-        authCache.put(targetHost, new BasicScheme());
-        
-        CredentialsProvider credsProvider = new BasicCredentialsProvider();
-        UsernamePasswordCredentials credentials
-         = new UsernamePasswordCredentials(_serverConfig.getUserName(), _serverConfig.getPassword());
-        credsProvider.setCredentials(AuthScope.ANY, credentials);
-
-        // Add AuthCache to the execution context
-        final HttpClientContext context = HttpClientContext.create();
-        context.setCredentialsProvider(credsProvider);
-        context.setAuthCache(authCache);
-
-        URI url= buildUrl(part, postParams);
-        
-        HttpPost httpPost = new HttpPost(url.toString());
-        httpPost.addHeader("OCS-APIRequest", "true");
-        httpPost.addHeader("Content-Type", "application/x-www-form-urlencoded");
-        httpPost.setProtocolVersion(HttpVersion.HTTP_1_1);
-
-        CloseableHttpResponse response = httpclient.execute(httpPost, context);
-        try {
-            StatusLine statusLine= response.getStatusLine();
-            if (statusLine.getStatusCode() == HttpStatus.SC_OK)
-            {
-                HttpEntity entity = response.getEntity();
-                if (entity != null) {
-                    //long len = entity.getContentLength();
-                    return EntityUtils.toString(entity);
-                }                
-            }
-            else
-            {
-                return null;
-            }
-        } finally {
-            response.close();
-        }
-        return null;
-    }
-
-    protected String executeDelete(String part1, String part2) throws Exception
-    {
-        CloseableHttpClient httpclient = HttpClients.createDefault();
-        HttpHost targetHost = new HttpHost(_serverConfig.getServerName(), _serverConfig.getPort(), _serverConfig.isUseHTTPS() ? "https" : "http");
-        AuthCache authCache = new BasicAuthCache();
-        authCache.put(targetHost, new BasicScheme());
-        
-        CredentialsProvider credsProvider = new BasicCredentialsProvider();
-        UsernamePasswordCredentials credentials
-         = new UsernamePasswordCredentials(_serverConfig.getUserName(), _serverConfig.getPassword());
-        credsProvider.setCredentials(AuthScope.ANY, credentials);
-
-        // Add AuthCache to the execution context
-        final HttpClientContext context = HttpClientContext.create();
-        context.setCredentialsProvider(credsProvider);
-        context.setAuthCache(authCache);
-
-        URI url= buildUrl(part1+"/"+part2, null);
-        
-        HttpDelete httpPost = new HttpDelete(url.toString());
-        httpPost.addHeader("OCS-APIRequest", "true");
-        httpPost.addHeader("Content-Type", "application/x-www-form-urlencoded");
-        httpPost.setProtocolVersion(HttpVersion.HTTP_1_1);
-
-        CloseableHttpResponse response = httpclient.execute(httpPost, context);
-        try {
-            StatusLine statusLine= response.getStatusLine();
-            if (statusLine.getStatusCode() == HttpStatus.SC_OK)
-            {
-                HttpEntity entity = response.getEntity();
-                if (entity != null) {
-                    //long len = entity.getContentLength();
-                    return EntityUtils.toString(entity);
-                }                
-            }
-            else
-            {
-                return null;
-            }
-        } finally {
-            response.close();
-        }
-        return null;
-    }
-    
-    protected URI buildUrl(String subPath, List<NameValuePair> queryParams) 
-            throws URISyntaxException
-    {
-        URIBuilder uB= new URIBuilder()
-        .setScheme(_serverConfig.isUseHTTPS() ? "https" : "http")
-        .setHost(_serverConfig.getServerName())
-        .setUserInfo(_serverConfig.getUserName(), _serverConfig.getPassword())
-        .setPath(subPath);
-        if (queryParams != null)
-        {
-            uB.addParameters(queryParams);
-        }
-        return uB.build();
     }
 }

--- a/src/main/java/org/aarboard/nextcloud/api/utils/ConnectorCommon.java
+++ b/src/main/java/org/aarboard/nextcloud/api/utils/ConnectorCommon.java
@@ -1,0 +1,213 @@
+package org.aarboard.nextcloud.api.utils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.aarboard.nextcloud.api.ServerConfig;
+import org.aarboard.nextcloud.api.exception.NextcloudApiException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpStatus;
+import org.apache.http.HttpVersion;
+import org.apache.http.NameValuePair;
+import org.apache.http.StatusLine;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+
+public class ConnectorCommon
+{
+    private final static Log LOG = LogFactory.getLog(ConnectorCommon.class);
+
+    private final ServerConfig serverConfig;
+
+    public ConnectorCommon(ServerConfig serverConfig) {
+        this.serverConfig = serverConfig;
+    }
+
+    public String executeGet(String part, List<NameValuePair> queryParams)
+    {
+        try {
+            return tryExecuteGet(part, queryParams);
+        } catch (IOException e) {
+            throw new NextcloudApiException(e);
+        }
+    }
+
+    private String tryExecuteGet(String part, List<NameValuePair> queryParams) throws IOException
+    {
+        CloseableHttpClient httpclient = HttpClients.createDefault();
+        HttpHost targetHost = new HttpHost(serverConfig.getServerName(), serverConfig.getPort(), serverConfig.isUseHTTPS() ? "https" : "http");
+        AuthCache authCache = new BasicAuthCache();
+        authCache.put(targetHost, new BasicScheme());
+
+        CredentialsProvider credsProvider = new BasicCredentialsProvider();
+        UsernamePasswordCredentials credentials
+         = new UsernamePasswordCredentials(serverConfig.getUserName(), serverConfig.getPassword());
+        credsProvider.setCredentials(AuthScope.ANY, credentials);
+
+        // Add AuthCache to the execution context
+        final HttpClientContext context = HttpClientContext.create();
+        context.setCredentialsProvider(credsProvider);
+        context.setAuthCache(authCache);
+
+        URI url= buildUrl(part, queryParams);
+
+        HttpGet httpget = new HttpGet(url.toString());
+        httpget.addHeader("OCS-APIRequest", "true");
+        httpget.addHeader("Content-Type", "application/x-www-form-urlencoded");
+        httpget.setProtocolVersion(HttpVersion.HTTP_1_1);
+
+        try(CloseableHttpResponse response = httpclient.execute(httpget, context)) {
+            StatusLine statusLine= response.getStatusLine();
+            if (statusLine.getStatusCode() == HttpStatus.SC_OK)
+            {
+                HttpEntity entity = response.getEntity();
+                if (entity != null) {
+                    return EntityUtils.toString(entity);
+                }
+            }
+            else
+            {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    public String executePost(String part, List<NameValuePair> postParams)
+    {
+        try {
+            return tryExecutePost(part, postParams);
+        } catch (IOException e) {
+            throw new NextcloudApiException(e);
+        }
+    }
+
+    private String tryExecutePost(String part, List<NameValuePair> postParams) throws IOException
+    {
+        CloseableHttpClient httpclient = HttpClients.createDefault();
+        HttpHost targetHost = new HttpHost(serverConfig.getServerName(), serverConfig.getPort(), serverConfig.isUseHTTPS()  ? "https" : "http");
+        AuthCache authCache = new BasicAuthCache();
+        authCache.put(targetHost, new BasicScheme());
+
+        CredentialsProvider credsProvider = new BasicCredentialsProvider();
+        UsernamePasswordCredentials credentials
+         = new UsernamePasswordCredentials(serverConfig.getUserName(), serverConfig.getPassword());
+        credsProvider.setCredentials(AuthScope.ANY, credentials);
+
+        // Add AuthCache to the execution context
+        final HttpClientContext context = HttpClientContext.create();
+        context.setCredentialsProvider(credsProvider);
+        context.setAuthCache(authCache);
+
+        URI url= buildUrl(part, postParams);
+
+        HttpPost httpPost = new HttpPost(url.toString());
+        httpPost.addHeader("OCS-APIRequest", "true");
+        httpPost.addHeader("Content-Type", "application/x-www-form-urlencoded");
+        httpPost.setProtocolVersion(HttpVersion.HTTP_1_1);
+
+        try(CloseableHttpResponse response = httpclient.execute(httpPost, context)) {
+            StatusLine statusLine= response.getStatusLine();
+            if (statusLine.getStatusCode() == HttpStatus.SC_OK)
+            {
+                HttpEntity entity = response.getEntity();
+                if (entity != null) {
+                    return EntityUtils.toString(entity);
+                }
+            }
+            else
+            {
+                LOG.warn("Post failed "+statusLine.getReasonPhrase()+" "+statusLine.getStatusCode());
+                return null;
+            }
+        }
+        return null;
+    }
+
+    public String executeDelete(String part1, String part2)
+    {
+        try {
+            return tryExecuteDelete(part1, part2);
+        } catch (IOException e) {
+            throw new NextcloudApiException(e);
+        }
+    }
+
+    private String tryExecuteDelete(String part1, String part2) throws IOException
+    {
+        CloseableHttpClient httpclient = HttpClients.createDefault();
+        HttpHost targetHost = new HttpHost(serverConfig.getServerName(), serverConfig.getPort(), serverConfig.isUseHTTPS() ? "https" : "http");
+        AuthCache authCache = new BasicAuthCache();
+        authCache.put(targetHost, new BasicScheme());
+
+        CredentialsProvider credsProvider = new BasicCredentialsProvider();
+        UsernamePasswordCredentials credentials
+         = new UsernamePasswordCredentials(serverConfig.getUserName(), serverConfig.getPassword());
+        credsProvider.setCredentials(AuthScope.ANY, credentials);
+
+        // Add AuthCache to the execution context
+        final HttpClientContext context = HttpClientContext.create();
+        context.setCredentialsProvider(credsProvider);
+        context.setAuthCache(authCache);
+
+        URI url= buildUrl(part1+"/"+part2, null);
+
+        HttpDelete httpPost = new HttpDelete(url.toString());
+        httpPost.addHeader("OCS-APIRequest", "true");
+        httpPost.addHeader("Content-Type", "application/x-www-form-urlencoded");
+        httpPost.setProtocolVersion(HttpVersion.HTTP_1_1);
+
+        try (CloseableHttpResponse response = httpclient.execute(httpPost, context)) {
+            StatusLine statusLine= response.getStatusLine();
+            if (statusLine.getStatusCode() == HttpStatus.SC_OK)
+            {
+                HttpEntity entity = response.getEntity();
+                if (entity != null) {
+                    return EntityUtils.toString(entity);
+                }
+            }
+            else
+            {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private URI buildUrl(String subPath, List<NameValuePair> queryParams)
+    {
+        URIBuilder uB= new URIBuilder()
+        .setScheme(serverConfig.isUseHTTPS() ? "https" : "http")
+        .setHost(serverConfig.getServerName())
+        .setUserInfo(serverConfig.getUserName(), serverConfig.getPassword())
+        .setPath(subPath);
+        if (queryParams != null)
+        {
+            uB.addParameters(queryParams);
+        }
+        try {
+            return uB.build();
+        } catch (URISyntaxException e) {
+            throw new NextcloudApiException(e);
+        }
+    }
+}

--- a/src/main/java/org/aarboard/nextcloud/api/utils/XMLAnswer.java
+++ b/src/main/java/org/aarboard/nextcloud/api/utils/XMLAnswer.java
@@ -46,7 +46,7 @@ public class XMLAnswer {
     }
 
     
-    public void parseAnswer(String xmlAnswer) throws Exception
+    public void parseAnswer(String xmlAnswer)
     {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setXIncludeAware(false);

--- a/src/main/java/org/aarboard/nextcloud/api/webdav/Folders.java
+++ b/src/main/java/org/aarboard/nextcloud/api/webdav/Folders.java
@@ -19,9 +19,12 @@ package org.aarboard.nextcloud.api.webdav;
 import com.github.sardine.DavResource;
 import com.github.sardine.Sardine;
 import com.github.sardine.SardineFactory;
+
+import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import org.aarboard.nextcloud.api.ServerConfig;
+import org.aarboard.nextcloud.api.exception.NextcloudApiException;
 
 /**
  *
@@ -38,14 +41,19 @@ public class Folders {
     }
 
     
-    public List<String> getFolders(String rootPath) throws Exception
+    public List<String> getFolders(String rootPath)
     {
         String path=  (_serverConfig.isUseHTTPS() ? "https" : "http") +"://"+_serverConfig.getServerName()+"/"+WEB_DAV_BASE_PATH+rootPath ;
         
         List<String> retVal= new LinkedList<>();
         Sardine sardine = SardineFactory.begin();
         sardine.setCredentials(_serverConfig.getUserName(), _serverConfig.getPassword());
-        List<DavResource> resources = sardine.list(path);
+        List<DavResource> resources;
+        try {
+            resources = sardine.list(path);
+        } catch (IOException e) {
+            throw new NextcloudApiException(e);
+        }
         for (DavResource res : resources)
         {
             retVal.add(res.getName());
@@ -53,31 +61,43 @@ public class Folders {
         return retVal;
     }
     
-    public boolean exists(String rootPath)  throws Exception
+    public boolean exists(String rootPath)
     {
         String path=  (_serverConfig.isUseHTTPS() ? "https" : "http") +"://"+_serverConfig.getServerName()+"/"+WEB_DAV_BASE_PATH+rootPath ;
         
         Sardine sardine = SardineFactory.begin();
         sardine.setCredentials(_serverConfig.getUserName(), _serverConfig.getPassword());
-        return sardine.exists(path);
+        try {
+            return sardine.exists(path);
+        } catch (IOException e) {
+            throw new NextcloudApiException(e);
+        }
     }
 
-    public void createFolder(String rootPath) throws Exception
+    public void createFolder(String rootPath)
     {
         String path=  (_serverConfig.isUseHTTPS() ? "https" : "http") +"://"+_serverConfig.getServerName()+"/"+WEB_DAV_BASE_PATH+rootPath ;
         
         Sardine sardine = SardineFactory.begin();
         sardine.setCredentials(_serverConfig.getUserName(), _serverConfig.getPassword());
-        sardine.createDirectory(path);
+        try {
+            sardine.createDirectory(path);
+        } catch (IOException e) {
+            throw new NextcloudApiException(e);
+        }
     }
 
-    public void deleteFolder(String rootPath) throws Exception
+    public void deleteFolder(String rootPath)
     {
         String path=  (_serverConfig.isUseHTTPS() ? "https" : "http") +"://"+_serverConfig.getServerName()+"/"+WEB_DAV_BASE_PATH+rootPath ;
         
         Sardine sardine = SardineFactory.begin();
         sardine.setCredentials(_serverConfig.getUserName(), _serverConfig.getPassword());
-        sardine.delete(path);
+        try {
+            sardine.delete(path);
+        } catch (IOException e) {
+            throw new NextcloudApiException(e);
+        }
     }
 }
 


### PR DESCRIPTION
The Exception base class should not be thrown by every method, instead I wrapped all thrown Exceptions in NextcloudApiException extended from RuntimeException, which is more specific and does not force the user to wrap every invocation in a try/catch clause or pass the throws declaration down the whole stack.

I also implemented the functionality to create and delete a user and extracted the common functionality from FilesharingConnector and ProvisionConnector into ConnectorCommon.