### PR TITLE
Update getFolders() method name, added recursion feature

### DIFF
--- a/src/main/java/org/aarboard/nextcloud/api/NextcloudConnector.java
+++ b/src/main/java/org/aarboard/nextcloud/api/NextcloudConnector.java
@@ -535,10 +535,35 @@ public class NextcloudConnector {
      *
      * @param path path of the folder
      * @return found subfolders
+     * @deprecated The methods naming is somehow misleading, as it lists all resources (subfolders and files) within the given {@code rootPath}. Please use {@link #listFolderContent(String)} instead.
      */
+    @Deprecated
     public List<String> getFolders(String path)
     {
         return fd.getFolders(path);
+    }
+
+    /**
+     * Get all subfolders of the specified path
+     *
+     * @param path path of the folder
+     * @return found subfolders
+     */
+    public List<String> listFolderContent(String path)
+    {
+        return fd.listFolderContent(path);
+    }
+
+    /**
+     * List all file names and subfolders of the specified path traversing into subfolders to the given depth.
+     *
+     * @param path path of the folder
+     * @param depth depth of recursion while listing folder contents
+     * @return found file names and subfolders
+     */
+    public List<String> listFolderContent(String path, int depth)
+    {
+        return fd.listFolderContent(path, depth);
     }
 
     /**
@@ -595,16 +620,16 @@ public class NextcloudConnector {
     }
 
     /**
-    * Shares the specified path with the provided parameters asynchronously
-    *
-    * @param path                  path to the file/folder which should be shared
-    * @param shareType             0 = user; 1 = group; 3 = public link; 6 = federated cloud share
-    * @param shareWithUserOrGroupId user / group id with which the file should be shared
-    * @param publicUpload          allow public upload to a public shared folder (true/false)
-    * @param password              password to protect public link Share with
-    * @param permissions           1 = read; 2 = update; 4 = create; 8 = delete; 16 = share; 31 = all (default: 31, for public shares: 1)
-    * @return a CompletableFuture containing the result of the operation
-    */
+     * Shares the specified path with the provided parameters asynchronously
+     *
+     * @param path                  path to the file/folder which should be shared
+     * @param shareType             0 = user; 1 = group; 3 = public link; 6 = federated cloud share
+     * @param shareWithUserOrGroupId user / group id with which the file should be shared
+     * @param publicUpload          allow public upload to a public shared folder (true/false)
+     * @param password              password to protect public link Share with
+     * @param permissions           1 = read; 2 = update; 4 = create; 8 = delete; 16 = share; 31 = all (default: 31, for public shares: 1)
+     * @return a CompletableFuture containing the result of the operation
+     */
     public CompletableFuture<SingleShareXMLAnswer> doShareAsync(
             String path,
             ShareType shareType,
@@ -659,10 +684,10 @@ public class NextcloudConnector {
     }
 
     /** Uploads a file at the specified path with the data from the InputStream
-    *
-    * @param inputStream          InputStream of the file which should be uploaded
-    * @param remotePath           path where the file should be uploaded to
-    */
+     *
+     * @param inputStream          InputStream of the file which should be uploaded
+     * @param remotePath           path where the file should be uploaded to
+     */
     public void uploadFile(InputStream inputStream, String remotePath)
     {
         fl.uploadFile(inputStream, remotePath);

--- a/src/main/java/org/aarboard/nextcloud/api/webdav/Folders.java
+++ b/src/main/java/org/aarboard/nextcloud/api/webdav/Folders.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2017 a.schild
  *
  * This program is free software: you can redistribute it and/or modify
@@ -16,15 +16,16 @@
  */
 package org.aarboard.nextcloud.api.webdav;
 
-import com.github.sardine.DavResource;
-import com.github.sardine.Sardine;
-import com.github.sardine.SardineFactory;
-
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
+
 import org.aarboard.nextcloud.api.ServerConfig;
 import org.aarboard.nextcloud.api.exception.NextcloudApiException;
+
+import com.github.sardine.DavResource;
+import com.github.sardine.Sardine;
+import com.github.sardine.SardineFactory;
 
 /**
  *
@@ -45,17 +46,43 @@ public class Folders {
      *
      * @param rootPath path of the folder
      * @return found subfolders
+     *
+     * @deprecated The methods naming is somehow misleading, as it lists all resources (subfolders and files) within the given {@code rootPath}. Please use {@link #listFolderContent(String)} instead.
      */
+    @Deprecated
     public List<String> getFolders(String rootPath)
     {
-        String path=  (_serverConfig.isUseHTTPS() ? "https" : "http") +"://"+_serverConfig.getServerName()+"/"+WEB_DAV_BASE_PATH+rootPath ;
+        return listFolderContent(rootPath);
+    }
+
+    /**
+     * List all file names and subfolders of the specified path
+     *
+     * @param path path of the folder
+     * @return found file names and subfolders
+     */
+    public List<String> listFolderContent(String path)
+    {
+        return listFolderContent(path, 1);
+    }
+
+    /**
+     * List all file names and subfolders of the specified path traversing into subfolders to the given depth.
+     *
+     * @param path path of the folder
+     * @param depth depth of recursion while listing folder contents
+     * @return found file names and subfolders
+     */
+    public List<String> listFolderContent(String path, int depth)
+    {
+        String url = (_serverConfig.isUseHTTPS() ? "https" : "http") +"://"+_serverConfig.getServerName()+"/"+WEB_DAV_BASE_PATH+path ;
 
         List<String> retVal= new LinkedList<>();
         Sardine sardine = SardineFactory.begin();
         sardine.setCredentials(_serverConfig.getUserName(), _serverConfig.getPassword());
         List<DavResource> resources;
         try {
-            resources = sardine.list(path);
+            resources = sardine.list(url, depth);
         } catch (IOException e) {
             throw new NextcloudApiException(e);
         }

--- a/src/test/java/org/aarboard/nextcloud/api/NextcloudConnectorTest.java
+++ b/src/test/java/org/aarboard/nextcloud/api/NextcloudConnectorTest.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2017 a.schild
  *
  * This program is free software: you can redistribute it and/or modify
@@ -352,6 +352,46 @@ public class NextcloudConnectorTest {
         if (_nc != null)
         {
             _nc.removeFile(TESTFILE);
+        }
+    }
+
+    @Test
+    public void t28_testList() {
+        System.out.println("list");
+
+        if (_nc != null)
+        {
+            //prepare
+            _nc.createFolder(TEST_FOLDER);
+
+            String rootPath = "";
+            List<String> result = _nc.listFolderContent(rootPath);
+
+            //cleanup
+            _nc.deleteFolder(TEST_FOLDER);
+
+            assertNotNull(result);
+            assertTrue(result.contains(TEST_FOLDER));
+        }
+    }
+
+    @Test
+    public void t29_testListRecursive() {
+        System.out.println("list recursive");
+        if (_nc != null)
+        {
+            //prepare
+            _nc.createFolder(TEST_FOLDER);
+            _nc.createFolder(TEST_FOLDER+"/"+TEST_FOLDER+"_sub");
+
+            String rootPath = "";
+            List<String> result = _nc.listFolderContent(rootPath, 2);
+
+            //cleanup
+            _nc.deleteFolder(TEST_FOLDER);
+
+            assertNotNull(result);
+            assertTrue(result.contains(TEST_FOLDER+"_sub"));
         }
     }
 }


### PR DESCRIPTION
First of all, thanks a lot for this cool lib 👍 

I was trying to list all content of a directory and everything I found was the `getFolders()` method, so I thought the library doesn't provide the feature of listing everything yet... so I had a look at Sardine to find out that `getFolders()` already does exactly what I need :)

I marked `getFolders()` as deprecated and added `listFolderContent()` with a javadoc that is a bit clearer in my opinion.
Additionally there's now the possibility to provide a `depth` parameter to list file names and subfolders also recursively.

EDIT: Argh, just saw that I accidentally committed some formatting changes also, sorry :(. Please let me know if I should revert them in case you want to merge this PR