### PR TITLE
Support for bearer authentication

### DIFF
--- a/src/main/java/org/aarboard/nextcloud/api/AuthenticationConfig.java
+++ b/src/main/java/org/aarboard/nextcloud/api/AuthenticationConfig.java
@@ -1,0 +1,53 @@
+package src.main.java.org.aarboard.nextcloud.api;
+
+public package org.aarboard.nextcloud.api;
+
+public class AuthenticationConfig {
+
+    private String userName;
+    private String password;
+
+    private String bearerToken;
+
+    public AuthenticationConfig(String userName, String password) {
+        this.userName = userName;
+        this.password = password;
+    }
+
+    public AuthenticationConfig(String bearerToken) {
+        this.bearerToken = bearerToken;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getBearerToken() {
+        return bearerToken;
+    }
+
+    public void setBearerToken(String bearerToken) {
+        this.bearerToken = bearerToken;
+    }
+
+    public boolean usesBasicAuthentication() {
+        return bearerToken == null;
+    }
+
+    public boolean usesBearerTokenAuthentication() {
+        return !usesBasicAuthentication();
+    }
+
+}

--- a/src/main/java/org/aarboard/nextcloud/api/NextcloudConnector.java
+++ b/src/main/java/org/aarboard/nextcloud/api/NextcloudConnector.java
@@ -51,46 +51,84 @@ public class NextcloudConnector {
     private final Files fl;
 
     /**
-     * 
-     * @param serverName    Name or IP of server of your nextcloud instance
-     * @param useHTTPS      Set true when https should be used
-     * @param port          Use 443 for https and 80 for non-https in most cases
-     * @param userName      User for login
-     * @param password      Password for login
+     *
+     * @param serverName Name or IP of server of your nextcloud instance
+     * @param useHTTPS   Set true when https should be used
+     * @param port       Use 443 for https and 80 for non-https in most cases
+     * @param userName   User for login
+     * @param password   Password for login
      */
-    public NextcloudConnector(String serverName, boolean useHTTPS, int port, String userName, String password)
-    {
-        _serverConfig= new ServerConfig(serverName, useHTTPS, port, userName, password);
-        pc= new ProvisionConnector(_serverConfig);
-        fc= new FilesharingConnector(_serverConfig);
-        cc= new ConfigConnector(_serverConfig);
-        fd= new Folders(_serverConfig);
-        fl= new Files(_serverConfig);
+    public NextcloudConnector(String serverName, boolean useHTTPS, int port, String userName, String password) {
+        this(serverName, useHTTPS, port, new AuthenticationConfig(userName, password));
     }
-    
+
     /**
-     * @param serviceUrl 	url of the nextcloud instance, e.g. https://nextcloud.instance.com:8443/cloud
-     * @param userName 		User for login
-     * @param password 		Password for login
+     *
+     * @param serverName  Name or IP of server of your nextcloud instance
+     * @param useHTTPS    Set true when https should be used
+     * @param port        Use 443 for https and 80 for non-https in most cases
+     * @param bearerToken Bearer token for login
      */
-	public NextcloudConnector(String serviceUrl, String userName, String password){
-		try {
-			URL _serviceUrl = new URL(serviceUrl);
-			boolean useHTTPS = serviceUrl.startsWith("https");
-			_serverConfig = new ServerConfig(_serviceUrl.getHost(), useHTTPS, _serviceUrl.getPort(),
-				userName, password);
-			if(!_serviceUrl.getPath().isEmpty()) {
-				_serverConfig.setSubPathPrefix(_serviceUrl.getPath());
-			}
-			pc = new ProvisionConnector(_serverConfig);
-			fc = new FilesharingConnector(_serverConfig);
-			cc= new ConfigConnector(_serverConfig);
-			fd = new Folders(_serverConfig);
-			fl = new Files(_serverConfig);
-		} catch (MalformedURLException e) {
-			throw new IllegalArgumentException(e);
-		}
-	}
+    public NextcloudConnector(String serverName, boolean useHTTPS, int port, String bearerToken) {
+        this(serverName, useHTTPS, port, new AuthenticationConfig(bearerToken));
+    }
+
+    /**
+     * @param serviceUrl url of the nextcloud instance, e.g. https://nextcloud.instance.com:8443/cloud
+     * @param userName   User for login
+     * @param password   Password for login
+     */
+    public NextcloudConnector(String serviceUrl, String userName, String password) {
+        this(serviceUrl, new AuthenticationConfig(userName, password));
+    }
+
+    /**
+     * @param serviceUrl  url of the nextcloud instance, e.g. https://nextcloud.instance.com:8443/cloud
+     * @param bearerToken Bearer token for login
+     */
+    public NextcloudConnector(String serviceUrl, String bearerToken) {
+        this(serviceUrl, new AuthenticationConfig(bearerToken));
+    }
+
+    /**
+     *
+     * @param serverName           Name or IP of server of your nextcloud instance
+     * @param useHTTPS             Set true when https should be used
+     * @param port                 Use 443 for https and 80 for non-https in most cases
+     * @param AuthenticationConfig Authentication configuration for login
+     */
+    public NextcloudConnector(String serverName, boolean useHTTPS, int port,
+            AuthenticationConfig authenticationConfig) {
+        _serverConfig = new ServerConfig(serverName, useHTTPS, port, authenticationConfig);
+        pc = new ProvisionConnector(_serverConfig);
+        fc = new FilesharingConnector(_serverConfig);
+        cc = new ConfigConnector(_serverConfig);
+        fd = new Folders(_serverConfig);
+        fl = new Files(_serverConfig);
+    }
+
+    /**
+     * @param serviceUrl           url of the nextcloud instance, e.g. https://nextcloud.instance.com:8443/cloud
+     * @param AuthenticationConfig Authentication configuration for login
+     */
+    public NextcloudConnector(String serviceUrl, AuthenticationConfig authenticationConfig) {
+        try {
+            URL _serviceUrl = new URL(serviceUrl);
+            boolean useHTTPS = serviceUrl.startsWith("https");
+            _serverConfig = new ServerConfig(_serviceUrl.getHost(), useHTTPS, _serviceUrl.getPort(),
+                    authenticationConfig);
+            if (!_serviceUrl.getPath().isEmpty()) {
+                _serverConfig.setSubPathPrefix(_serviceUrl.getPath());
+            }
+            pc = new ProvisionConnector(_serverConfig);
+            fc = new FilesharingConnector(_serverConfig);
+            cc = new ConfigConnector(_serverConfig);
+            fd = new Folders(_serverConfig);
+            fl = new Files(_serverConfig);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
 
 	/**
 	 * Close the HTTP client. Perform this to cleanly shut down this application.

--- a/src/main/java/org/aarboard/nextcloud/api/NextcloudConnector.java
+++ b/src/main/java/org/aarboard/nextcloud/api/NextcloudConnector.java
@@ -95,7 +95,7 @@ public class NextcloudConnector {
      * @param serverName           Name or IP of server of your nextcloud instance
      * @param useHTTPS             Set true when https should be used
      * @param port                 Use 443 for https and 80 for non-https in most cases
-     * @param AuthenticationConfig Authentication configuration for login
+     * @param authenticationConfig Authentication configuration for login
      */
     public NextcloudConnector(String serverName, boolean useHTTPS, int port,
             AuthenticationConfig authenticationConfig) {
@@ -109,7 +109,7 @@ public class NextcloudConnector {
 
     /**
      * @param serviceUrl           url of the nextcloud instance, e.g. https://nextcloud.instance.com:8443/cloud
-     * @param AuthenticationConfig Authentication configuration for login
+     * @param authenticationConfig Authentication configuration for login
      */
     public NextcloudConnector(String serviceUrl, AuthenticationConfig authenticationConfig) {
         try {

--- a/src/main/java/org/aarboard/nextcloud/api/ServerConfig.java
+++ b/src/main/java/org/aarboard/nextcloud/api/ServerConfig.java
@@ -22,8 +22,7 @@ package org.aarboard.nextcloud.api;
  */
 public class ServerConfig {
     
-    private String userName;
-    private String password;
+    private AuthenticationConfig authenticationConfig;
     private String serverName;
     private String subPathPrefix;
     private boolean useHTTPS;
@@ -43,10 +42,8 @@ public class ServerConfig {
     public ServerConfig(String serverName, 
             boolean useHTTPS, 
             int port, 
-            String userName, 
-            String password) {
-        this.userName = userName;
-        this.password = password;
+            AuthenticationConfig authenticationConfig) {
+        this.authenticationConfig = authenticationConfig;
         this.serverName = serverName;
         this.subPathPrefix = null;
         this.useHTTPS = useHTTPS;
@@ -71,10 +68,8 @@ public class ServerConfig {
             boolean useHTTPS, 
             int port, 
             String subPathPrefix,
-            String userName, 
-            String password) {
-        this.userName = userName;
-        this.password = password;
+            AuthenticationConfig authenticationConfig) {
+        this.authenticationConfig = authenticationConfig;
         this.serverName = serverName;
         this.subPathPrefix = subPathPrefix;
         this.useHTTPS = useHTTPS;
@@ -83,31 +78,17 @@ public class ServerConfig {
     }
 
     /**
-     * @return the userName
+     * @return the authenticationConfig
      */
-    public String getUserName() {
-        return userName;
+    public AuthenticationConfig getAuthenticationConfig() {
+        return authenticationConfig;
     }
 
     /**
-     * @param userName the userName to set
+     * @param authenticationConfig authenticationConfig to set
      */
-    public void setUserName(String userName) {
-        this.userName = userName;
-    }
-
-    /**
-     * @return the password
-     */
-    public String getPassword() {
-        return password;
-    }
-
-    /**
-     * @param password the password to set
-     */
-    public void setPassword(String password) {
-        this.password = password;
+    public void setAuthenticationConfig(AuthenticationConfig authenticationConfig) {
+        this.authenticationConfig = authenticationConfig;
     }
 
     /**

--- a/src/main/java/org/aarboard/nextcloud/api/ServerConfig.java
+++ b/src/main/java/org/aarboard/nextcloud/api/ServerConfig.java
@@ -33,11 +33,10 @@ public class ServerConfig {
      * Use this constructor if your nextcloud instance is installed in the 
      * root of the webhosting, like https://nextcloud.company.my/
      * 
-     * @param serverName    ip or dns name of server
-     * @param useHTTPS      Use https or http to connect
-     * @param port          Port, usuallay 443 for https and 80 for http
-     * @param userName      User name for authentication
-     * @param password      Password for authentication
+     * @param serverName           ip or dns name of server
+     * @param useHTTPS             Use https or http to connect
+     * @param port                 Port, usuallay 443 for https and 80 for http
+     * @param authenticationConfig Authentication configuration for authentication
      */
     public ServerConfig(String serverName, 
             boolean useHTTPS, 
@@ -55,13 +54,12 @@ public class ServerConfig {
      * Is this constructor if your nextcloud is installed in a subfolder of the server
      * like https://nextcloud.company.my/<b>nextcloud/</b>
      * 
-     * @param serverName    ip or dns name of server
-     * @param useHTTPS      Use https or http to connect
-     * @param port          Port, usuallay 443 for https and 80 for http
-     * @param subPathPrefix Path to your nextcloud instance, without starting and trailing /
-     *                      can be null if installed in root
-     * @param userName      User name for authentication
-     * @param password      Password for authentication
+     * @param serverName           ip or dns name of server
+     * @param useHTTPS             Use https or http to connect
+     * @param port                 Port, usuallay 443 for https and 80 for http
+     * @param subPathPrefix        Path to your nextcloud instance, without starting and trailing /
+     *                             can be null if installed in root
+     * @param authenticationConfig Authentication configuration for authentication
      */
     public ServerConfig(
             String serverName, 

--- a/src/main/java/org/aarboard/nextcloud/api/webdav/AWebdavHandler.java
+++ b/src/main/java/org/aarboard/nextcloud/api/webdav/AWebdavHandler.java
@@ -18,6 +18,7 @@ package org.aarboard.nextcloud.api.webdav;
 
 import com.github.sardine.Sardine;
 import com.github.sardine.SardineFactory;
+import com.github.sardine.impl.SardineImpl;
 import java.io.IOException;
 import org.aarboard.nextcloud.api.ServerConfig;
 import org.aarboard.nextcloud.api.exception.NextcloudApiException;
@@ -68,10 +69,13 @@ public abstract class AWebdavHandler {
      */
     protected Sardine buildAuthSardine()
     {
-        Sardine sardine = SardineFactory.begin();
-        sardine.setCredentials(_serverConfig.getUserName(), _serverConfig.getPassword());
-        sardine.enablePreemptiveAuthentication(_serverConfig.getServerName());
-        
+        if (_serverConfig.getAuthenticationConfig().usesBasicAuthentication()) {
+            Sardine sardine = SardineFactory.begin();
+            sardine.setCredentials(_serverConfig.getUserName(), _serverConfig.getPassword());
+            sardine.enablePreemptiveAuthentication(_serverConfig.getServerName());
+            return sardine;
+        }
+        Sardine sardine = new SardineImpl(_serverConfig.getAuthenticationConfig().getBearerToken());
         return sardine;
     }
     

--- a/src/test/java/org/aarboard/nextcloud/api/filesharing/FilesharingConnectorTest.java
+++ b/src/test/java/org/aarboard/nextcloud/api/filesharing/FilesharingConnectorTest.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import org.aarboard.nextcloud.api.AuthenticationConfig;
 import org.aarboard.nextcloud.api.NextcloudConnector;
 import org.aarboard.nextcloud.api.ServerConfig;
 import org.aarboard.nextcloud.api.TestHelper;
@@ -69,7 +70,7 @@ public class FilesharingConnectorTest {
         serverPort= th.getServerPort();
         if (serverName != null)
         {
-            _sc= new ServerConfig(serverName, serverPort == 443, serverPort, userName, password);
+            _sc= new ServerConfig(serverName, serverPort == 443, serverPort, new AuthenticationConfig(userName, password));
             _nc = new NextcloudConnector(serverName, serverPort == 443, serverPort, userName, password);
             _nc.createFolder(TEST_FOLDER);
             _nc.createFolder(TEST_FOLDER2);


### PR DESCRIPTION
Fixes https://github.com/a-schild/nextcloud-java-api/issues/10

Usage:
```java
NextcloudConnector connector = new NextcloudConnector(serviceUrl, bearerToken);
```

Note that if you are not able to authenticate with a valid bearer token, you should check that the `WEB_DAV_BASE_PATH` field in `AWebdavHandler` is valid. That url must be `remote.php/dav` in most recent Nextcloud versions.

Also note that the `/files/{user}` path is not automatically added as it is with basic authentication.