### PR TITLE
Let the user customize the base path url

### DIFF
--- a/src/main/java/org/aarboard/nextcloud/api/webdav/AWebdavHandler.java
+++ b/src/main/java/org/aarboard/nextcloud/api/webdav/AWebdavHandler.java
@@ -33,7 +33,7 @@ public abstract class AWebdavHandler {
     private static final Logger LOG = LoggerFactory.getLogger(AWebdavHandler.class);
 
     public static final int  FILE_BUFFER_SIZE= 4096;
-    private static final String WEB_DAV_BASE_PATH = "remote.php/webdav/";
+    public static String WEB_DAV_BASE_PATH = "remote.php/webdav/";
     
     private final ServerConfig _serverConfig;
 

--- a/src/main/java/org/aarboard/nextcloud/api/webdav/Folders.java
+++ b/src/main/java/org/aarboard/nextcloud/api/webdav/Folders.java
@@ -120,11 +120,11 @@ public class Folders extends AWebdavHandler{
         {
             if (excludeFolderNames) {
                 if (!res.isDirectory()) {
-                    retVal.add(returnFullPath ? res.getPath().replaceFirst("/remote.php/webdav/", "") : res.getName());
+                    retVal.add(returnFullPath ? res.getPath().replaceFirst("/" + AWebdavHandler.WEB_DAV_BASE_PATH + "/", "") : res.getName());
                 }
             }
             else {
-                retVal.add(returnFullPath ? res.getPath().replaceFirst("/remote.php/webdav/", "") : res.getName());
+                retVal.add(returnFullPath ? res.getPath().replaceFirst("/" + AWebdavHandler.WEB_DAV_BASE_PATH + "/", "") : res.getName());
             }
         }
         return retVal;


### PR DESCRIPTION
The url `remote.php/webdav` is being replaced by `remote.php/dav` as seen in https://github.com/nextcloud/server/issues/25867.

Users using the most recent versions of Nextcloud should therefore be able to customize that static field in order to not get a 404.

Linked to https://github.com/a-schild/nextcloud-java-api/pull/52, but this one is a lazy fix.