### PR TITLE
set HttpAsyncClientSingleton.HTTPC_CLIENT = null on shutdown

### DIFF
--- a/src/main/java/org/aarboard/nextcloud/api/utils/ConnectorCommon.java
+++ b/src/main/java/org/aarboard/nextcloud/api/utils/ConnectorCommon.java
@@ -273,6 +273,7 @@ public class ConnectorCommon
     public static void shutdown() throws IOException {
             if(HttpAsyncClientSingleton.HTTPC_CLIENT != null) {
                 HttpAsyncClientSingleton.getInstance(null).close();
+                HttpAsyncClientSingleton.HTTPC_CLIENT = null;
             }		
     }
 }


### PR DESCRIPTION
when using the NextcloudConnector, shutting it down with NextcloudConnector.shutdown() and using it afterwards again in the same JVM (for example when executing multiple integration-tests after each other) the HTTPC_CLIENT does not get initialized because its not null. the HTTPC_CLIENT-instance is in the STOPPED-state, so further executions with the client dont work.

PR: cleanup singleton-instance of HttpAsyncClientSingleton.HTTPC_CLIENT by setting the HTTP_CLIENT to null on ConnectorCommon.shutdown()