### PR TITLE
Bump Java Version to 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
         <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
         <cyclonedx-maven-plugin.version>2.7.9</cyclonedx-maven-plugin.version>
 
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <netbeans.hint.license>gpl30</netbeans.hint.license>
     </properties>
     <name>NextCloud Java API library</name>


### PR DESCRIPTION
Reason: The pom.xml specified Java 8 as source and target, which makes jitpack.io try to compile the code using JDK 8. However, the code can't compile at Java 8 (Class version <= 52.0) due to XML-Bind API needing Java 11 (Class <= 55.0)

```
ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile (default-compile) on project nextcloud-api: Compilation failure
[ERROR] /home/klenk/Dev/idm/libraries/nextcloud-java-api/src/main/java/org/aarboard/nextcloud/api/config/AppConfigAppsAnswer.java:[19,35] cannot access jakarta.xml.bind.annotation.XmlAccessType
[ERROR]   bad class file: /home/klenk/.m2/repository/jakarta/xml/bind/jakarta.xml.bind-api/4.0.1/jakarta.xml.bind-api-4.0.1.jar(jakarta/xml/bind/annotation/XmlAccessType.class)
[ERROR]     class file has wrong version 55.0, should be 52.0
[ERROR]     Please remove or make sure it appears in the correct subdirectory of the classpath.
```