### PR TITLE
The stream should be closed by the consumer.

### DIFF
--- a/src/main/java/org/aarboard/nextcloud/api/provisioning/ShareData.java
+++ b/src/main/java/org/aarboard/nextcloud/api/provisioning/ShareData.java
@@ -5,7 +5,8 @@ public enum ShareData
     PERMISSIONS("permissions"),
     PASSWORD("password"),
     PUBLICUPLOAD("publicUpload"),
-    EXPIREDATE("expireDate");
+    EXPIREDATE("expireDate"),
+	HIDEDOWNLOAD("hideDownload");
 
     public final String parameterName;
 

--- a/src/main/java/org/aarboard/nextcloud/api/webdav/Files.java
+++ b/src/main/java/org/aarboard/nextcloud/api/webdav/Files.java
@@ -205,17 +205,6 @@ public class Files extends AWebdavHandler{
         {
             throw new NextcloudApiException(e);
         }
-        finally
-        {
-            try
-            {
-                sardine.shutdown();
-            }
-            catch(Exception ex2)
-            {
-                LOG.warn(ERROR_SHUTDOWN, ex2);
-            }
-        }
         return in;
     }
     


### PR DESCRIPTION
Call the method in autocloseable mode to ensure the release of all resources.

Using
```java
...
    try(var is = nc.downloadFile(path)){
        var buffer = is.readAllBytes();
        ...
    }
...
```

Fixes #61 