### PR TITLE
Set expiry date when creating a share (#76)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog for nextcloud api
 
+## Version 14.1.6
+- Add optional `expireDate` parameter to `doShare` / `doShareAsync`, so an
+  expiration date can be set when creating a share (issue #76)
+
 ## Version 14.1.5
 - 2026-07-24
   - Updated dependencies:

--- a/src/main/java/org/aarboard/nextcloud/api/NextcloudConnector.java
+++ b/src/main/java/org/aarboard/nextcloud/api/NextcloudConnector.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.LocalDate;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import org.aarboard.nextcloud.api.config.ConfigConnector;
@@ -897,6 +898,33 @@ public class NextcloudConnector implements AutoCloseable {
     }
 
     /**
+     * Shares the specified path with the provided parameters
+     *
+     * @param path path to the file/folder which should be shared
+     * @param shareType 0 = user; 1 = group; 3 = public link; 4 = email; 6 =
+     * federated cloud share
+     * @param shareWithUserOrGroupId user / group id / email with which the file
+     * should be shared
+     * @param publicUpload allow public upload to a public shared folder
+     * (true/false)
+     * @param password password to protect public link Share with
+     * @param permissions 1 = read; 2 = update; 4 = create; 8 = delete; 16 =
+     * share; 31 = all (default: 31, for public shares: 1)
+     * @param expireDate expiration date of the share, or null for no expiration
+     * @return created share on success
+     */
+    public Share doShare(
+            String path,
+            ShareType shareType,
+            String shareWithUserOrGroupId,
+            Boolean publicUpload,
+            String password,
+            SharePermissions permissions,
+            LocalDate expireDate) {
+        return fc.doShare(path, shareType, shareWithUserOrGroupId, publicUpload, password, permissions, expireDate);
+    }
+
+    /**
      * Shares the specified path with the provided parameters asynchronously
      *
      * @param path path to the file/folder which should be shared
@@ -919,6 +947,33 @@ public class NextcloudConnector implements AutoCloseable {
             String password,
             SharePermissions permissions) {
         return fc.doShareAsync(path, shareType, shareWithUserOrGroupId, publicUpload, password, permissions);
+    }
+
+    /**
+     * Shares the specified path with the provided parameters asynchronously
+     *
+     * @param path path to the file/folder which should be shared
+     * @param shareType 0 = user; 1 = group; 3 = public link; 4 = email; 6 =
+     * federated cloud share
+     * @param shareWithUserOrGroupId user / group id / email with which the file
+     * should be shared
+     * @param publicUpload allow public upload to a public shared folder
+     * (true/false)
+     * @param password password to protect public link Share with
+     * @param permissions 1 = read; 2 = update; 4 = create; 8 = delete; 16 =
+     * share; 31 = all (default: 31, for public shares: 1)
+     * @param expireDate expiration date of the share, or null for no expiration
+     * @return a CompletableFuture containing the result of the operation
+     */
+    public CompletableFuture<SingleShareXMLAnswer> doShareAsync(
+            String path,
+            ShareType shareType,
+            String shareWithUserOrGroupId,
+            Boolean publicUpload,
+            String password,
+            SharePermissions permissions,
+            LocalDate expireDate) {
+        return fc.doShareAsync(path, shareType, shareWithUserOrGroupId, publicUpload, password, permissions, expireDate);
     }
 
     /**

--- a/src/main/java/org/aarboard/nextcloud/api/filesharing/FilesharingConnector.java
+++ b/src/main/java/org/aarboard/nextcloud/api/filesharing/FilesharingConnector.java
@@ -16,6 +16,7 @@
  */
 package org.aarboard.nextcloud.api.filesharing;
 
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -162,7 +163,31 @@ public class FilesharingConnector
             String password,
             SharePermissions permissions)
     {
-        return NextcloudResponseHelper.getAndCheckStatus(doShareAsync(path, shareType, shareWithUserOrGroupIdOrEmail, publicUpload, password, permissions)).getShare();
+        return doShare(path, shareType, shareWithUserOrGroupIdOrEmail, publicUpload, password, permissions, null);
+    }
+
+    /**
+     * Shares the specified path with the provided parameters
+     *
+     * @param path                  path to the file/folder which should be shared
+     * @param shareType             0 = user; 1 = group; 3 = public link; 4 = email; 6 = federated cloud share
+     * @param shareWithUserOrGroupIdOrEmail user / group id / email with which the file should be shared
+     * @param publicUpload          allow public upload to a public shared folder (true/false)
+     * @param password              password to protect public link Share with
+     * @param permissions           1 = read; 2 = update; 4 = create; 8 = delete; 16 = share; 31 = all (default: 31, for public shares: 1)
+     * @param expireDate            expiration date of the share, or null for no expiration
+     * @return created share on success
+     */
+    public Share doShare(
+            String path,
+            ShareType shareType,
+            String shareWithUserOrGroupIdOrEmail,
+            Boolean publicUpload,
+            String password,
+            SharePermissions permissions,
+            LocalDate expireDate)
+    {
+        return NextcloudResponseHelper.getAndCheckStatus(doShareAsync(path, shareType, shareWithUserOrGroupIdOrEmail, publicUpload, password, permissions, expireDate)).getShare();
     }
 
     /**
@@ -184,6 +209,30 @@ public class FilesharingConnector
             String password,
             SharePermissions permissions)
     {
+        return doShareAsync(path, shareType, shareWithUserOrGroupIdOrEmail, publicUpload, password, permissions, null);
+    }
+
+    /**
+    * Shares the specified path with the provided parameters asynchronously
+    *
+    * @param path                  path to the file/folder which should be shared
+    * @param shareType             0 = user; 1 = group; 3 = public link; 4 = email; 6 = federated cloud share
+    * @param shareWithUserOrGroupIdOrEmail user / group id / email with which the file should be shared
+    * @param publicUpload          allow public upload to a public shared folder (true/false)
+    * @param password              password to protect public link Share with
+    * @param permissions           1 = read; 2 = update; 4 = create; 8 = delete; 16 = share; 31 = all (default: 31, for public shares: 1)
+    * @param expireDate            expiration date of the share, or null for no expiration
+    * @return a CompletableFuture containing the result of the operation
+    */
+    public CompletableFuture<SingleShareXMLAnswer> doShareAsync(
+            String path,
+            ShareType shareType,
+            String shareWithUserOrGroupIdOrEmail,
+            Boolean publicUpload,
+            String password,
+            SharePermissions permissions,
+            LocalDate expireDate)
+    {
         List<NameValuePair> postParams= new LinkedList<>();
         postParams.add(new BasicNameValuePair("path", path));
         postParams.add(new BasicNameValuePair("shareType", Integer.toString(shareType.getIntValue())));
@@ -199,6 +248,10 @@ public class FilesharingConnector
         if (permissions != null)
         {
             postParams.add(new BasicNameValuePair("permissions", Integer.toString(permissions.getCurrentPermission())));
+        }
+        if (expireDate != null)
+        {
+            postParams.add(new BasicNameValuePair("expireDate", expireDate.toString()));
         }
 
         return connectorCommon.executePost(SHARES_PART, postParams, XMLAnswerParser.getInstance(SingleShareXMLAnswer.class));

--- a/src/test/java/org/aarboard/nextcloud/api/filesharing/FilesharingConnectorTest.java
+++ b/src/test/java/org/aarboard/nextcloud/api/filesharing/FilesharingConnectorTest.java
@@ -239,4 +239,18 @@ public class FilesharingConnectorTest {
         }
     }
 
+    @Test
+    public void t09_testDoShareWithExpireDate() {
+        System.out.println("shareFolderWithExpireDate");
+        if (_sc != null)
+        {
+            FilesharingConnector instance = new FilesharingConnector(_sc);
+            SharePermissions permissions = new SharePermissions(SingleRight.READ);
+            LocalDate expireDate = LocalDate.of(9999, 3, 3);
+            Share result = instance.doShare(TEST_FOLDER2, ShareType.PUBLIC_LINK, "", true, "1234-myWebDav", permissions, expireDate);
+            assertNotNull(result);
+            assertEquals(expireDate, result.getExpiration());
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary

Implements #76: allow setting an expiration date when **creating** a share.

The library already supported reading a share's expiration (`Share.getExpiration()`) and editing it on an existing share (`ShareData.EXPIREDATE` via `editShare`), but there was no way to set it at creation time. This adds that.

## Changes

- `FilesharingConnector.doShare` / `doShareAsync`: new overloads with a trailing `java.time.LocalDate expireDate`. When non-null it is sent to the OCS share API as the `expireDate` parameter in ISO `YYYY-MM-DD` form (`LocalDate.toString()`, matching the existing `LocalDateXmlAdapter`).
- `NextcloudConnector` facade: mirrored overloads delegating to the connector.
- The existing 6-argument methods are kept and delegate with a `null` expireDate, so the change is **fully backwards compatible** (no signature changes).
- Added test `t09_testDoShareWithExpireDate` creating a public link with an expiry and asserting `getExpiration()`.
- Changelog entry under 14.1.6.

## Design note

Used `LocalDate` rather than `String` for type safety and consistency with `Share.getExpiration()`, which already returns `LocalDate`.

## Verification

`mvn clean test-compile` passes (main + test sources compile). The new test is an integration test and requires a live Nextcloud server (skipped by default like the rest of the share tests).

Follow-up: #107 tracks the remaining OCS Share API gaps (federated shares, note/label, additional share types).

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)
