### PR TITLE
CI: move actions off deprecated Node 20 (checkout v7, setup-java v5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     name: Build and integration test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '11'
           distribution: 'zulu'


### PR DESCRIPTION
Bumps the CI workflow actions to the versions already used by maven-publish.yaml, resolving the runner warning that actions/checkout@v4 and actions/setup-java@v4 target the deprecated Node.js 20:

- actions/checkout v4 -> v7
- actions/setup-java v4 -> v5

Both run on Node.js 24. Workflow-only change.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

🤖 Generated with [Claude Code](https://claude.com/claude-code)