### PR TITLE
Fix WebDAV uploads on non-standard ports (#112)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,10 @@
 ## Version 14.1.6
 - Add optional `expireDate` parameter to `doShare` / `doShareAsync`, so an
   expiration date can be set when creating a share (issue #76)
+- Fix file uploads (and other WebDAV writes) failing on servers running on a
+  non-standard port: preemptive authentication now uses the configured port, so
+  the server no longer issues an auth challenge that a streamed upload cannot
+  retry (issue #112)
 - Testing: integration tests can now auto-provision a throw-away Nextcloud
   server via Testcontainers when Docker is available, and are executed in CI
   (GitHub Actions)

--- a/src/main/java/org/aarboard/nextcloud/api/webdav/AWebdavHandler.java
+++ b/src/main/java/org/aarboard/nextcloud/api/webdav/AWebdavHandler.java
@@ -179,7 +179,13 @@ public abstract class AWebdavHandler
             Sardine sardine = SardineFactory.begin();
             sardine.setCredentials(this.serverConfig.getUserName(),
                     this.serverConfig.getAuthenticationConfig().getPassword());
-            sardine.enablePreemptiveAuthentication(this.serverConfig.getServerName());
+            // Pass the configured port so preemptive authentication also applies
+            // on non-standard ports (e.g. behind a reverse proxy). Without it the
+            // hostname-only overload assumes ports 80/443, the server then issues
+            // an auth challenge, and non-repeatable requests such as a streamed
+            // file upload (PUT) fail because they cannot be retried.
+            sardine.enablePreemptiveAuthentication(this.serverConfig.getServerName(),
+                    this.serverConfig.getPort(), this.serverConfig.getPort());
             return sardine;
         }
       return new SardineImpl(this.serverConfig.getAuthenticationConfig().getBearerToken());


### PR DESCRIPTION
Apply preemptive auth on the configured port for WebDAV (issue #112)

buildAuthSardine() enabled preemptive basic authentication with the
hostname-only Sardine overload, which assumes the standard ports 80/443.
On a server reachable on a non-standard port the preemptive credentials
were therefore not sent, the server responded with an auth challenge, and
non-repeatable requests such as a streamed file upload (PUT) failed with
"Cannot retry request with a non-repeatable request entity".

Use the port-aware enablePreemptiveAuthentication(host, httpPort,
httpsPort) overload with the configured port so uploads work regardless
of the port (e.g. behind a reverse proxy, or the containerized server used
by the integration tests).

Read-only/repeatable WebDAV operations were unaffected because they can be
retried after the challenge, which is why folder tests passed while file
upload/download/rename/remove failed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
