### PR TITLE
CI: gate on the now-green integration suite (closes #112)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,7 @@ jobs:
 
       # Docker is preinstalled on ubuntu-latest runners, so Testcontainers can
       # spin up the throw-away Nextcloud server used by the integration tests.
+      # GPG signing is bound to the verify phase but is only needed for
+      # releases (the publish workflow supplies the key), so skip it here.
       - name: Build and run tests
-        run: mvn --batch-mode --update-snapshots verify -DskipTests=false
+        run: mvn --batch-mode --update-snapshots verify -DskipTests=false -Dgpg.skip=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,5 @@ jobs:
 
       # Docker is preinstalled on ubuntu-latest runners, so Testcontainers can
       # spin up the throw-away Nextcloud server used by the integration tests.
-      #
-      # continue-on-error is temporary: ~45 tests currently fail against a clean
-      # Nextcloud 31 (tracked in #112). Remove it once the suite is green so CI
-      # gates again.
       - name: Build and run tests
-        continue-on-error: true
         run: mvn --batch-mode --update-snapshots verify -DskipTests=false


### PR DESCRIPTION
The full integration suite passes against a clean Nextcloud 31 (96/96), so the temporary continue-on-error is removed and CI gates on the tests again.

This completes the #112 work:
- Empty-collection JSON deserialization (#113)
- WebDAV uploads on non-standard ports (#115)
- Test container: disable password_policy (#116)

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)