### PR TITLE
Extend OCS Share API coverage (#107)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,13 @@
   quota via the new `GroupFolders` connector and `NextcloudConnector` methods
   (issue #109). Thanks to Denis Verkhovsky for the original implementation the
   port is based on.
+- Extend OCS Share API coverage (issue #107):
+  - Federated/remote shares: list accepted and pending shares, get info, delete,
+    and accept/decline pending shares
+  - (Re)send the share notification email via `sendShareEmail`
+  - New `ShareType` values `CIRCLE` (7) and `TALK` (10)
+  - New `ShareData` attributes `NOTE`, `LABEL`, `ATTRIBUTES`, `SENDMAIL` for
+    `editShare`, and `Share` now exposes `getNote()` / `getLabel()`
 
 ## Version 14.1.6
 - 2026-07-24

--- a/src/main/java/org/aarboard/nextcloud/api/NextcloudConnector.java
+++ b/src/main/java/org/aarboard/nextcloud/api/NextcloudConnector.java
@@ -30,6 +30,7 @@ import org.aarboard.nextcloud.api.filesharing.Share;
 import org.aarboard.nextcloud.api.filesharing.SharePermissions;
 import org.aarboard.nextcloud.api.filesharing.ShareType;
 import org.aarboard.nextcloud.api.filesharing.SharesXMLAnswer;
+import org.aarboard.nextcloud.api.filesharing.RemoteShare;
 import org.aarboard.nextcloud.api.filesharing.SingleShareXMLAnswer;
 import org.aarboard.nextcloud.api.groupfolders.GroupFolderInfo;
 import org.aarboard.nextcloud.api.groupfolders.GroupFolders;
@@ -192,6 +193,70 @@ public class NextcloudConnector implements AutoCloseable {
      */
     public void shutdown() throws IOException {
         ConnectorCommon.shutdown();
+    }
+
+    /**
+     * (Re)sends the share notification email to the recipients of a share
+     *
+     * @param shareId unique identifier of the share
+     * @return true if the operation succeeded
+     */
+    public boolean sendShareEmail(int shareId) {
+        return fc.sendShareEmail(shareId);
+    }
+
+    /**
+     * @return all accepted federated (server-to-server) shares of this user
+     */
+    public Collection<RemoteShare> getRemoteShares() {
+        return fc.getRemoteShares();
+    }
+
+    /**
+     * Gets information about a single accepted federated share
+     *
+     * @param remoteShareId id of the remote share
+     * @return the remote share if found, otherwise null
+     */
+    public RemoteShare getRemoteShareInfo(int remoteShareId) {
+        return fc.getRemoteShareInfo(remoteShareId);
+    }
+
+    /**
+     * Deletes (unshares) an accepted federated share
+     *
+     * @param remoteShareId id of the remote share
+     * @return true if the operation succeeded
+     */
+    public boolean deleteRemoteShare(int remoteShareId) {
+        return fc.deleteRemoteShare(remoteShareId);
+    }
+
+    /**
+     * @return all pending (not yet accepted) federated shares of this user
+     */
+    public Collection<RemoteShare> getPendingRemoteShares() {
+        return fc.getPendingRemoteShares();
+    }
+
+    /**
+     * Accepts a pending federated share
+     *
+     * @param remoteShareId id of the pending remote share
+     * @return true if the operation succeeded
+     */
+    public boolean acceptPendingRemoteShare(int remoteShareId) {
+        return fc.acceptPendingRemoteShare(remoteShareId);
+    }
+
+    /**
+     * Declines a pending federated share
+     *
+     * @param remoteShareId id of the pending remote share
+     * @return true if the operation succeeded
+     */
+    public boolean declinePendingRemoteShare(int remoteShareId) {
+        return fc.declinePendingRemoteShare(remoteShareId);
     }
 
     /**

--- a/src/main/java/org/aarboard/nextcloud/api/filesharing/FilesharingConnector.java
+++ b/src/main/java/org/aarboard/nextcloud/api/filesharing/FilesharingConnector.java
@@ -47,6 +47,7 @@ public class FilesharingConnector
 
     private static final String ROOT_PART= "ocs/v1.php/apps/files_sharing/api/v1/";
     private static final String SHARES_PART= ROOT_PART+"shares";
+    private static final String REMOTE_SHARES_PART= ROOT_PART+"remote_shares";
 
     private final ConnectorCommon connectorCommon;
 
@@ -329,5 +330,155 @@ public class FilesharingConnector
     public CompletableFuture<XMLAnswer> deleteShareAsync(int shareId)
     {
         return connectorCommon.executeDelete(SHARES_PART, Integer.toString(shareId), null, XMLAnswerParser.getInstance(XMLAnswer.class));
+    }
+
+    /**
+     * (Re)sends the share notification email to the recipients of a share
+     *
+     * @param shareId unique identifier of the share
+     * @return true if the operation succeeded
+     */
+    public boolean sendShareEmail(int shareId)
+    {
+        return NextcloudResponseHelper.isStatusCodeOkay(sendShareEmailAsync(shareId));
+    }
+
+    /**
+     * (Re)sends the share notification email to the recipients of a share asynchronously
+     *
+     * @param shareId unique identifier of the share
+     * @return a CompletableFuture containing the result of the operation
+     */
+    public CompletableFuture<XMLAnswer> sendShareEmailAsync(int shareId)
+    {
+        return connectorCommon.executePost(SHARES_PART+"/"+shareId+"/send-email", XMLAnswerParser.getInstance(XMLAnswer.class));
+    }
+
+    /**
+     * Gets all accepted federated (server-to-server) shares of this user
+     *
+     * @return accepted remote shares
+     */
+    public List<RemoteShare> getRemoteShares()
+    {
+        return NextcloudResponseHelper.getAndCheckStatus(getRemoteSharesAsync()).getRemoteShares();
+    }
+
+    /**
+     * Gets all accepted federated (server-to-server) shares of this user asynchronously
+     *
+     * @return a CompletableFuture containing the result of the operation
+     */
+    public CompletableFuture<RemoteSharesXMLAnswer> getRemoteSharesAsync()
+    {
+        return connectorCommon.executeGet(REMOTE_SHARES_PART, null, XMLAnswerParser.getInstance(RemoteSharesXMLAnswer.class));
+    }
+
+    /**
+     * Gets information about a single accepted federated share
+     *
+     * @param remoteShareId id of the remote share
+     * @return the remote share if found, otherwise null
+     */
+    public RemoteShare getRemoteShareInfo(int remoteShareId)
+    {
+        return NextcloudResponseHelper.getAndCheckStatus(getRemoteShareInfoAsync(remoteShareId)).getRemoteShare();
+    }
+
+    /**
+     * Gets information about a single accepted federated share asynchronously
+     *
+     * @param remoteShareId id of the remote share
+     * @return a CompletableFuture containing the result of the operation
+     */
+    public CompletableFuture<SingleRemoteShareXMLAnswer> getRemoteShareInfoAsync(int remoteShareId)
+    {
+        return connectorCommon.executeGet(REMOTE_SHARES_PART+"/"+remoteShareId, null, XMLAnswerParser.getInstance(SingleRemoteShareXMLAnswer.class));
+    }
+
+    /**
+     * Deletes (unshares) an accepted federated share
+     *
+     * @param remoteShareId id of the remote share
+     * @return true if the operation succeeded
+     */
+    public boolean deleteRemoteShare(int remoteShareId)
+    {
+        return NextcloudResponseHelper.isStatusCodeOkay(deleteRemoteShareAsync(remoteShareId));
+    }
+
+    /**
+     * Deletes (unshares) an accepted federated share asynchronously
+     *
+     * @param remoteShareId id of the remote share
+     * @return a CompletableFuture containing the result of the operation
+     */
+    public CompletableFuture<XMLAnswer> deleteRemoteShareAsync(int remoteShareId)
+    {
+        return connectorCommon.executeDelete(REMOTE_SHARES_PART, Integer.toString(remoteShareId), null, XMLAnswerParser.getInstance(XMLAnswer.class));
+    }
+
+    /**
+     * Gets all pending (not yet accepted) federated shares of this user
+     *
+     * @return pending remote shares
+     */
+    public List<RemoteShare> getPendingRemoteShares()
+    {
+        return NextcloudResponseHelper.getAndCheckStatus(getPendingRemoteSharesAsync()).getRemoteShares();
+    }
+
+    /**
+     * Gets all pending (not yet accepted) federated shares of this user asynchronously
+     *
+     * @return a CompletableFuture containing the result of the operation
+     */
+    public CompletableFuture<RemoteSharesXMLAnswer> getPendingRemoteSharesAsync()
+    {
+        return connectorCommon.executeGet(REMOTE_SHARES_PART+"/pending", null, XMLAnswerParser.getInstance(RemoteSharesXMLAnswer.class));
+    }
+
+    /**
+     * Accepts a pending federated share
+     *
+     * @param remoteShareId id of the pending remote share
+     * @return true if the operation succeeded
+     */
+    public boolean acceptPendingRemoteShare(int remoteShareId)
+    {
+        return NextcloudResponseHelper.isStatusCodeOkay(acceptPendingRemoteShareAsync(remoteShareId));
+    }
+
+    /**
+     * Accepts a pending federated share asynchronously
+     *
+     * @param remoteShareId id of the pending remote share
+     * @return a CompletableFuture containing the result of the operation
+     */
+    public CompletableFuture<XMLAnswer> acceptPendingRemoteShareAsync(int remoteShareId)
+    {
+        return connectorCommon.executePost(REMOTE_SHARES_PART+"/pending/"+remoteShareId, XMLAnswerParser.getInstance(XMLAnswer.class));
+    }
+
+    /**
+     * Declines a pending federated share
+     *
+     * @param remoteShareId id of the pending remote share
+     * @return true if the operation succeeded
+     */
+    public boolean declinePendingRemoteShare(int remoteShareId)
+    {
+        return NextcloudResponseHelper.isStatusCodeOkay(declinePendingRemoteShareAsync(remoteShareId));
+    }
+
+    /**
+     * Declines a pending federated share asynchronously
+     *
+     * @param remoteShareId id of the pending remote share
+     * @return a CompletableFuture containing the result of the operation
+     */
+    public CompletableFuture<XMLAnswer> declinePendingRemoteShareAsync(int remoteShareId)
+    {
+        return connectorCommon.executeDelete(REMOTE_SHARES_PART+"/pending", Integer.toString(remoteShareId), null, XMLAnswerParser.getInstance(XMLAnswer.class));
     }
 }

--- a/src/main/java/org/aarboard/nextcloud/api/filesharing/RemoteShare.java
+++ b/src/main/java/org/aarboard/nextcloud/api/filesharing/RemoteShare.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2026 a.schild
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.aarboard.nextcloud.api.filesharing;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+
+/**
+ * A federated (server-to-server) share as returned by the OCS
+ * {@code remote_shares} endpoints.
+ *
+ * @author a.schild
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+public class RemoteShare
+{
+    private int         id;
+    private String      remote;
+    @XmlElement(name = "remote_id")
+    private String      remoteId;
+    @XmlElement(name = "share_token")
+    private String      shareToken;
+    private String      name;
+    private String      owner;
+    private String      user;
+    private String      mountpoint;
+    private String      mimetype;
+    private String      mtime;
+    private String      permissions;
+    private String      type;
+    @XmlElement(name = "file_id")
+    private String      fileId;
+    private boolean     accepted;
+
+    public int getId() {
+        return id;
+    }
+
+    public String getRemote() {
+        return remote;
+    }
+
+    public String getRemoteId() {
+        return remoteId;
+    }
+
+    public String getShareToken() {
+        return shareToken;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public String getMountpoint() {
+        return mountpoint;
+    }
+
+    public String getMimetype() {
+        return mimetype;
+    }
+
+    public String getMtime() {
+        return mtime;
+    }
+
+    public String getPermissions() {
+        return permissions;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getFileId() {
+        return fileId;
+    }
+
+    public boolean isAccepted() {
+        return accepted;
+    }
+}

--- a/src/main/java/org/aarboard/nextcloud/api/filesharing/RemoteSharesXMLAnswer.java
+++ b/src/main/java/org/aarboard/nextcloud/api/filesharing/RemoteSharesXMLAnswer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 a.schild
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.aarboard.nextcloud.api.filesharing;
+
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+import org.aarboard.nextcloud.api.utils.XMLAnswer;
+
+/**
+ * Answer of the "list federated/remote shares" calls.
+ *
+ * @author a.schild
+ */
+@XmlRootElement(name = "ocs")
+public class RemoteSharesXMLAnswer extends XMLAnswer
+{
+    @XmlElementWrapper(name = "data")
+    @XmlElement(name = "element")
+    private List<RemoteShare> remoteShares;
+
+    public List<RemoteShare> getRemoteShares() {
+        return remoteShares;
+    }
+}

--- a/src/main/java/org/aarboard/nextcloud/api/filesharing/Share.java
+++ b/src/main/java/org/aarboard/nextcloud/api/filesharing/Share.java
@@ -64,6 +64,8 @@ public class Share
     private LocalDate   expiration;
     private String url;
     private String mimetype;
+    private String note;
+    private String label;
 
     public int getId() {
         return id;
@@ -131,6 +133,14 @@ public class Share
 
     public String getMimetype() {
         return mimetype;
+    }
+
+    public String getNote() {
+        return note;
+    }
+
+    public String getLabel() {
+        return label;
     }
 
     private static final class SharePermissionsAdapter extends XmlAdapter<Integer, SharePermissions>

--- a/src/main/java/org/aarboard/nextcloud/api/filesharing/ShareType.java
+++ b/src/main/java/org/aarboard/nextcloud/api/filesharing/ShareType.java
@@ -34,7 +34,9 @@ public enum ShareType {
     @XmlEnumValue("1") GROUP(1),
     @XmlEnumValue("3") PUBLIC_LINK(3),
     @XmlEnumValue("4") EMAIL(4),
-    @XmlEnumValue("6") FEDERATED_CLOUD_SHARE(6);
+    @XmlEnumValue("6") FEDERATED_CLOUD_SHARE(6),
+    @XmlEnumValue("7") CIRCLE(7),
+    @XmlEnumValue("10") TALK(10);
 
     private final int intValue;
     

--- a/src/main/java/org/aarboard/nextcloud/api/filesharing/SingleRemoteShareXMLAnswer.java
+++ b/src/main/java/org/aarboard/nextcloud/api/filesharing/SingleRemoteShareXMLAnswer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 a.schild
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.aarboard.nextcloud.api.filesharing;
+
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.aarboard.nextcloud.api.utils.XMLAnswer;
+
+/**
+ * Answer of the "get single federated/remote share" call.
+ *
+ * @author a.schild
+ */
+@XmlRootElement(name = "ocs")
+public class SingleRemoteShareXMLAnswer extends XMLAnswer
+{
+    @XmlElement(name = "data")
+    private RemoteShare remoteShare = null;
+
+    public RemoteShare getRemoteShare() {
+        return remoteShare;
+    }
+}

--- a/src/main/java/org/aarboard/nextcloud/api/provisioning/ShareData.java
+++ b/src/main/java/org/aarboard/nextcloud/api/provisioning/ShareData.java
@@ -6,7 +6,11 @@ public enum ShareData
     PASSWORD("password"),
     PUBLICUPLOAD("publicUpload"),
     EXPIREDATE("expireDate"),
-	HIDEDOWNLOAD("hideDownload");
+	HIDEDOWNLOAD("hideDownload"),
+    NOTE("note"),
+    LABEL("label"),
+    ATTRIBUTES("attributes"),
+    SENDMAIL("sendMail");
 
     public final String parameterName;
 

--- a/src/test/java/org/aarboard/nextcloud/api/filesharing/FilesharingConnectorTest.java
+++ b/src/test/java/org/aarboard/nextcloud/api/filesharing/FilesharingConnectorTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.fail;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -250,6 +251,43 @@ public class FilesharingConnectorTest {
             Share result = instance.doShare(TEST_FOLDER2, ShareType.PUBLIC_LINK, "", true, "1234-myWebDav", permissions, expireDate);
             assertNotNull(result);
             assertEquals(expireDate, result.getExpiration());
+        }
+    }
+
+    @Test
+    public void t10_testEditShareNoteAndLabel() {
+        System.out.println("editShareNoteAndLabel");
+        if (_sc != null)
+        {
+            FilesharingConnector instance = new FilesharingConnector(_sc);
+            SharePermissions permissions = new SharePermissions(SingleRight.READ);
+            Share created = instance.doShare(TEST_FOLDER2, ShareType.PUBLIC_LINK, "", true, "1234-myWebDav", permissions);
+            assertNotNull(created);
+
+            assertTrue(instance.editShare(created.getId(), ShareData.NOTE, "my share note"));
+            assertTrue(instance.editShare(created.getId(), ShareData.LABEL, "my label"));
+
+            Share reloaded = instance.getShareInfo(created.getId());
+            assertEquals("my share note", reloaded.getNote());
+            assertEquals("my label", reloaded.getLabel());
+
+            assertTrue(instance.deleteShare(created.getId()));
+        }
+    }
+
+    @Test
+    public void t11_testGetRemoteShares() {
+        System.out.println("getRemoteShares");
+        if (_sc != null)
+        {
+            FilesharingConnector instance = new FilesharingConnector(_sc);
+            // On a single, non-federated server these are simply empty; the call
+            // must complete and parse without error.
+            List<RemoteShare> accepted = instance.getRemoteShares();
+            assertTrue(accepted == null || accepted.isEmpty());
+
+            List<RemoteShare> pending = instance.getPendingRemoteShares();
+            assertTrue(pending == null || pending.isEmpty());
         }
     }
 

--- a/src/test/java/org/aarboard/nextcloud/api/filesharing/ShareTypeTest.java
+++ b/src/test/java/org/aarboard/nextcloud/api/filesharing/ShareTypeTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 a.schild
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.aarboard.nextcloud.api.filesharing;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Pure unit tests for the {@link ShareType} mapping (no server required).
+ *
+ * @author a.schild
+ */
+public class ShareTypeTest {
+
+    @Test
+    public void testIntValues() {
+        assertEquals(7, ShareType.CIRCLE.getIntValue());
+        assertEquals(10, ShareType.TALK.getIntValue());
+    }
+
+    @Test
+    public void testGetShareTypeForIntValue() {
+        assertEquals(ShareType.CIRCLE, ShareType.getShareTypeForIntValue(7));
+        assertEquals(ShareType.TALK, ShareType.getShareTypeForIntValue(10));
+        assertEquals(ShareType.FEDERATED_CLOUD_SHARE, ShareType.getShareTypeForIntValue(6));
+    }
+}


### PR DESCRIPTION
Implements the bulk of #107.

## Added
- **Federated / remote shares**: `getRemoteShares`, `getRemoteShareInfo`, `deleteRemoteShare`, `getPendingRemoteShares`, `acceptPendingRemoteShare`, `declinePendingRemoteShare` (sync + async) with a new `RemoteShare` model and XML answers.
- **Send share email**: `sendShareEmail(shareId)` -> `POST /shares/{id}/send-email`.
- **ShareType**: `CIRCLE` (7) and `TALK` (10).
- **ShareData**: `NOTE`, `LABEL`, `ATTRIBUTES`, `SENDMAIL` for `editShare`; `Share` now exposes `getNote()` / `getLabel()`.
- Facade methods on `NextcloudConnector` for all of the above.

## Testing
- `ShareTypeTest` (pure unit test).
- `editShare` note/label round-trip via `getShareInfo` and a remote-shares smoke test in `FilesharingConnectorTest`.
- Full federation (two servers) is out of scope for the container test rig, so the remote-shares calls are smoke-tested (endpoint + XML parsing) against a single server; the accept/decline flows are code-complete but not exercised end-to-end.

## Not included / deferred
- Adding note/label/hideDownload as positional params on `doShare` (the signature is already large); they are settable via `editShare`. Can be revisited if a create-time API is desired.

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)