### PR TITLE
Security: fix XXE in XML parsing + remove credentials from request URLs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 # Changelog for nextcloud api
 
 ## Version 14.2.0
+- Security: harden XML response parsing against XXE by disabling DTDs and
+  external entities in the StAX parser
+- Security: no longer embed the basic-auth credentials in the request URL
+  (they are sent via the request context instead), avoiding password leakage
+  through logs, proxies or exceptions
 - Add support for the Group Folders app: create, rename, delete and list group
   folders, grant/revoke group access, set group permissions and set the folder
   quota via the new `GroupFolders` connector and `NextcloudConnector` methods

--- a/src/main/java/org/aarboard/nextcloud/api/utils/ConnectorCommon.java
+++ b/src/main/java/org/aarboard/nextcloud/api/utils/ConnectorCommon.java
@@ -134,10 +134,9 @@ public class ConnectorCommon
         .setPort(serverConfig.getPort())
         .setPath(subPath);
 
-        if (serverConfig.getAuthenticationConfig().usesBasicAuthentication()) {
-            uB.setUserInfo(serverConfig.getAuthenticationConfig().getLoginName(),
-                serverConfig.getAuthenticationConfig().getPassword());
-        }
+        // Basic auth credentials are supplied via the request context
+        // (see prepareContext()); they are deliberately NOT embedded in the URL
+        // to avoid leaking the password through logs, proxies or exceptions.
 
         if (queryParams != null) {
             uB.addParameters(queryParams);

--- a/src/main/java/org/aarboard/nextcloud/api/utils/XMLAnswerParser.java
+++ b/src/main/java/org/aarboard/nextcloud/api/utils/XMLAnswerParser.java
@@ -7,6 +7,9 @@ import java.io.IOException;
 import java.io.Reader;
 import java.util.HashMap;
 import java.util.Map;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 import org.aarboard.nextcloud.api.exception.NextcloudApiException;
 import org.aarboard.nextcloud.api.utils.ConnectorCommon.ResponseParser;
 
@@ -14,7 +17,23 @@ public class XMLAnswerParser<A extends XMLAnswer> implements ResponseParser<A>
 {
     private static final Map<String, XMLAnswerParser<? extends XMLAnswer>> PARSERS = new HashMap<>();
 
+    /**
+     * Shared, hardened StAX factory. DTD support and external entity resolution
+     * are disabled to prevent XXE attacks from a malicious or MITM'd server
+     * response. The factory is only configured once here and thereafter used
+     * read-only, which is safe to share across threads.
+     */
+    private static final XMLInputFactory XML_INPUT_FACTORY = createHardenedInputFactory();
+
     private final JAXBContext jAXBContext;
+
+    private static XMLInputFactory createHardenedInputFactory()
+    {
+        XMLInputFactory factory = XMLInputFactory.newFactory();
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        return factory;
+    }
 
     public XMLAnswerParser(Class<A> answerClass)
     {
@@ -57,9 +76,15 @@ public class XMLAnswerParser<A extends XMLAnswer> implements ResponseParser<A>
     }
 
     @SuppressWarnings("unchecked")
-    private A tryParseAnswer(Reader xmlStream) throws JAXBException {
+    private A tryParseAnswer(Reader xmlStream) throws JAXBException, XMLStreamException {
         Unmarshaller unmarshaller = jAXBContext.createUnmarshaller();
-        Object result = unmarshaller.unmarshal(xmlStream);
-        return (A) result;
+        // Unmarshal through the hardened StAX reader (not the raw Reader) so
+        // DTDs / external entities are never processed.
+        XMLStreamReader xmlStreamReader = XML_INPUT_FACTORY.createXMLStreamReader(xmlStream);
+        try {
+            return (A) unmarshaller.unmarshal(xmlStreamReader);
+        } finally {
+            xmlStreamReader.close();
+        }
     }
 }

--- a/src/test/java/org/aarboard/nextcloud/api/utils/XMLAnswerParserSecurityTest.java
+++ b/src/test/java/org/aarboard/nextcloud/api/utils/XMLAnswerParserSecurityTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 a.schild
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.aarboard.nextcloud.api.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.StringReader;
+
+import org.aarboard.nextcloud.api.exception.NextcloudApiException;
+import org.aarboard.nextcloud.api.filesharing.SharesXMLAnswer;
+import org.junit.Test;
+
+/**
+ * Security tests for {@link XMLAnswerParser}: a malicious/MITM'd server
+ * response must not be able to trigger XXE, and valid XML must still parse.
+ *
+ * @author a.schild
+ */
+public class XMLAnswerParserSecurityTest {
+
+    /**
+     * A response declaring a DOCTYPE / external entity must be rejected (DTDs
+     * are disabled), so the entity is never resolved (no file read / SSRF).
+     */
+    @Test(expected = NextcloudApiException.class)
+    public void testExternalEntityIsNotResolved() {
+        String malicious = "<?xml version=\"1.0\"?>"
+                + "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/hostname\">]>"
+                + "<ocs><data><element><path>&xxe;</path></element></data></ocs>";
+        XMLAnswerParser.getInstance(SharesXMLAnswer.class)
+                .parseResponse(new StringReader(malicious));
+    }
+
+    /**
+     * Regression guard: hardening the parser must not break normal parsing.
+     */
+    @Test
+    public void testValidXmlStillParses() {
+        String valid = "<?xml version=\"1.0\"?>"
+                + "<ocs><meta><status>ok</status><statuscode>100</statuscode></meta>"
+                + "<data><element><id>1</id><path>/test</path></element></data></ocs>";
+        SharesXMLAnswer answer = XMLAnswerParser.getInstance(SharesXMLAnswer.class)
+                .parseResponse(new StringReader(valid));
+        assertNotNull(answer.getShares());
+        assertEquals(1, answer.getShares().size());
+        assertEquals("/test", answer.getShares().get(0).getPath());
+    }
+}


### PR DESCRIPTION
Addresses findings #1 (XXE) and #2 (credentials in URL) from the security review.

## 1. XXE in XML response parsing (high)
`XMLAnswerParser` unmarshalled the raw server `Reader` with JAXB's default parser, which processes DTDs and external entities. A malicious or MITM'd server response could read local files (`file://`), perform SSRF, or DoS via entity expansion.

**Fix:** unmarshal through a shared, hardened StAX `XMLStreamReader` with `SUPPORT_DTD=false` and `IS_SUPPORTING_EXTERNAL_ENTITIES=false`.

## 2. Credentials embedded in request URL (medium)
`ConnectorCommon.buildUrl` put `user:password@host` in every basic-auth request URL, risking password leakage via logs/proxies/exceptions. It was redundant — `prepareContext()` already supplies the credentials via the request context.

**Fix:** removed the `setUserInfo` call.

## Tests
- `XMLAnswerParserSecurityTest`: asserts a DOCTYPE/external-entity payload is rejected, and that valid XML still parses.
- The full integration suite validates that basic auth still works (every test authenticates) and that all XML answers still parse against real Nextcloud 31.

Refs #107-era security review. #3 (per-connector TLS/proxy on the static client) will follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)