### PR TITLE
Add system tags support (#110)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 # Changelog for nextcloud api
 
 ## Version 14.2.0
+- Add system tags support: list, create and delete system tags, and assign or
+  remove tags on a file via the new `SystemTags` connector and
+  `NextcloudConnector` methods (issue #110)
 - Security: harden XML response parsing against XXE by disabling DTDs and
   external entities in the StAX parser
 - Security: no longer embed the basic-auth credentials in the request URL

--- a/src/main/java/org/aarboard/nextcloud/api/NextcloudConnector.java
+++ b/src/main/java/org/aarboard/nextcloud/api/NextcloudConnector.java
@@ -37,6 +37,8 @@ import org.aarboard.nextcloud.api.filesharing.SingleShareXMLAnswer;
 import org.aarboard.nextcloud.api.groupfolders.GroupFolderInfo;
 import org.aarboard.nextcloud.api.groupfolders.GroupFolders;
 import org.aarboard.nextcloud.api.provisioning.*;
+import org.aarboard.nextcloud.api.systemtags.SystemTags;
+import org.aarboard.nextcloud.api.systemtags.Tag;
 import org.aarboard.nextcloud.api.utils.*;
 import org.aarboard.nextcloud.api.webdav.Files;
 import org.aarboard.nextcloud.api.webdav.Folders;
@@ -54,6 +56,7 @@ public class NextcloudConnector implements AutoCloseable {
     private final Folders fd;
     private final Files fl;
     private final GroupFolders gf;
+    private final SystemTags st;
 
     /**
      * 
@@ -117,6 +120,7 @@ public class NextcloudConnector implements AutoCloseable {
             fd = new Folders(this.serverConfig);
             fl = new Files(this.serverConfig);
             gf = new GroupFolders(this.serverConfig);
+            st = new SystemTags(this.serverConfig);
 
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException(e);
@@ -139,6 +143,7 @@ public class NextcloudConnector implements AutoCloseable {
         fd = new Folders(this.serverConfig);
         fl = new Files(this.serverConfig);
         gf = new GroupFolders(this.serverConfig);
+        st = new SystemTags(this.serverConfig);
     }
 
     /**
@@ -259,6 +264,62 @@ public class NextcloudConnector implements AutoCloseable {
      */
     public boolean declinePendingRemoteShare(int remoteShareId) {
         return fc.declinePendingRemoteShare(remoteShareId);
+    }
+
+    /**
+     * @return all system tags on the server
+     */
+    public java.util.List<Tag> getSystemTags() {
+        return st.getTags();
+    }
+
+    /**
+     * @param fileId numeric file id (see {@code getProperties(path, true).getFileId()})
+     * @return the system tags assigned to the given file
+     */
+    public java.util.List<Tag> getSystemTagsForFile(long fileId) {
+        return st.getTagsForFile(fileId);
+    }
+
+    /**
+     * Creates a new system tag.
+     *
+     * @param name           display name of the tag
+     * @param userVisible    whether the tag is visible to users
+     * @param userAssignable whether users can assign the tag
+     * @return the id of the created tag
+     */
+    public int createSystemTag(String name, boolean userVisible, boolean userAssignable) {
+        return st.createTag(name, userVisible, userAssignable);
+    }
+
+    /**
+     * Deletes a system tag.
+     *
+     * @param tagId id of the tag
+     */
+    public void deleteSystemTag(int tagId) {
+        st.deleteTag(tagId);
+    }
+
+    /**
+     * Assigns a system tag to a file.
+     *
+     * @param fileId numeric file id
+     * @param tagId  id of the tag
+     */
+    public void assignSystemTag(long fileId, int tagId) {
+        st.assignTag(fileId, tagId);
+    }
+
+    /**
+     * Removes a system tag from a file.
+     *
+     * @param fileId numeric file id
+     * @param tagId  id of the tag
+     */
+    public void removeSystemTag(long fileId, int tagId) {
+        st.removeTag(fileId, tagId);
     }
 
     /**

--- a/src/main/java/org/aarboard/nextcloud/api/systemtags/SystemTags.java
+++ b/src/main/java/org/aarboard/nextcloud/api/systemtags/SystemTags.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2026 a.schild
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.aarboard.nextcloud.api.systemtags;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.sardine.DavResource;
+import com.github.sardine.Sardine;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.net.ssl.SSLContext;
+import javax.xml.namespace.QName;
+import org.aarboard.nextcloud.api.ServerConfig;
+import org.aarboard.nextcloud.api.exception.NextcloudApiException;
+import org.aarboard.nextcloud.api.utils.SslUtils;
+import org.aarboard.nextcloud.api.webdav.AWebdavHandler;
+import org.apache.http.Header;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+
+/**
+ * Access to Nextcloud <a href="https://docs.nextcloud.com/server/latest/developer_manual/client_apis/WebDAV/tags.html">system
+ * tags</a> via the WebDAV {@code systemtags} / {@code systemtags-relations}
+ * endpoints: list, create and delete tags, and assign/remove tags on a file
+ * (identified by its numeric file id, obtainable from
+ * {@code getProperties(path, true).getFileId()}).
+ *
+ * @author a.schild
+ */
+public class SystemTags extends AWebdavHandler {
+
+    private static final String SYSTEMTAGS = "remote.php/dav/systemtags/";
+    private static final String SYSTEMTAGS_RELATIONS = "remote.php/dav/systemtags-relations/files/";
+    private static final String NS_OC = "http://owncloud.org/ns";
+
+    private static final QName PROP_ID = new QName(NS_OC, "id");
+    private static final QName PROP_DISPLAY_NAME = new QName(NS_OC, "display-name");
+    private static final QName PROP_USER_VISIBLE = new QName(NS_OC, "user-visible");
+    private static final QName PROP_USER_ASSIGNABLE = new QName(NS_OC, "user-assignable");
+    private static final QName PROP_CAN_ASSIGN = new QName(NS_OC, "can-assign");
+
+    public SystemTags(ServerConfig serverConfig) {
+        super(serverConfig);
+    }
+
+    /**
+     * @return all system tags on the server
+     */
+    public List<Tag> getTags() {
+        return propfindTags(buildDavUrl(SYSTEMTAGS));
+    }
+
+    /**
+     * @param fileId numeric file id (see {@code getProperties(path, true).getFileId()})
+     * @return the tags assigned to the given file
+     */
+    public List<Tag> getTagsForFile(long fileId) {
+        return propfindTags(buildDavUrl(SYSTEMTAGS_RELATIONS + fileId));
+    }
+
+    /**
+     * Creates a new system tag.
+     *
+     * @param name           display name of the tag
+     * @param userVisible    whether the tag is visible to users
+     * @param userAssignable whether users can assign the tag
+     * @return the id of the created tag
+     */
+    public int createTag(String name, boolean userVisible, boolean userAssignable) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("name", name);
+        body.put("userVisible", userVisible);
+        body.put("userAssignable", userAssignable);
+
+        HttpPost post = new HttpPost(buildDavUrl(SYSTEMTAGS));
+        post.setHeader("Authorization", authorizationHeader());
+        try {
+            post.setEntity(new StringEntity(new ObjectMapper().writeValueAsString(body),
+                    ContentType.APPLICATION_JSON));
+        } catch (IOException e) {
+            throw new NextcloudApiException(e);
+        }
+
+        try (CloseableHttpClient client = buildSyncClient();
+                CloseableHttpResponse response = client.execute(post)) {
+            int status = response.getStatusLine().getStatusCode();
+            if (status != 201) {
+                throw new NextcloudApiException("Creating system tag failed with status " + status);
+            }
+            Header location = response.getFirstHeader("Content-Location");
+            if (location == null) {
+                location = response.getFirstHeader("Location");
+            }
+            if (location == null) {
+                throw new NextcloudApiException("Creating system tag returned no location header");
+            }
+            String href = location.getValue().replaceAll("/$", "");
+            return Integer.parseInt(href.substring(href.lastIndexOf('/') + 1));
+        } catch (IOException e) {
+            throw new NextcloudApiException(e);
+        }
+    }
+
+    /**
+     * Deletes a system tag.
+     *
+     * @param tagId id of the tag
+     */
+    public void deleteTag(int tagId) {
+        davDelete(buildDavUrl(SYSTEMTAGS + tagId));
+    }
+
+    /**
+     * Assigns a system tag to a file.
+     *
+     * @param fileId numeric file id
+     * @param tagId  id of the tag
+     */
+    public void assignTag(long fileId, int tagId) {
+        Sardine sardine = buildAuthSardine();
+        try {
+            sardine.put(buildDavUrl(SYSTEMTAGS_RELATIONS + fileId + "/" + tagId), new byte[0]);
+        } catch (IOException e) {
+            throw new NextcloudApiException(e);
+        } finally {
+            shutdownSardine(sardine);
+        }
+    }
+
+    /**
+     * Removes a system tag from a file.
+     *
+     * @param fileId numeric file id
+     * @param tagId  id of the tag
+     */
+    public void removeTag(long fileId, int tagId) {
+        davDelete(buildDavUrl(SYSTEMTAGS_RELATIONS + fileId + "/" + tagId));
+    }
+
+    private void davDelete(String url) {
+        Sardine sardine = buildAuthSardine();
+        try {
+            sardine.delete(url);
+        } catch (IOException e) {
+            throw new NextcloudApiException(e);
+        } finally {
+            shutdownSardine(sardine);
+        }
+    }
+
+    private List<Tag> propfindTags(String url) {
+        Sardine sardine = buildAuthSardine();
+        try {
+            Set<QName> props = new HashSet<>();
+            props.add(PROP_ID);
+            props.add(PROP_DISPLAY_NAME);
+            props.add(PROP_USER_VISIBLE);
+            props.add(PROP_USER_ASSIGNABLE);
+            props.add(PROP_CAN_ASSIGN);
+
+            List<Tag> tags = new ArrayList<>();
+            for (DavResource resource : sardine.propfind(url, 1, props)) {
+                Map<QName, String> customProps = resource.getCustomPropsNS();
+                String id = customProps.get(PROP_ID);
+                if (id == null || id.isEmpty()) {
+                    // the collection itself has no id
+                    continue;
+                }
+                Tag tag = new Tag();
+                tag.setId(Integer.parseInt(id));
+                tag.setName(customProps.get(PROP_DISPLAY_NAME));
+                tag.setUserVisible(toBoolean(customProps.get(PROP_USER_VISIBLE)));
+                tag.setUserAssignable(toBoolean(customProps.get(PROP_USER_ASSIGNABLE)));
+                tag.setCanAssign(toBoolean(customProps.get(PROP_CAN_ASSIGN)));
+                tags.add(tag);
+            }
+            return tags;
+        } catch (IOException e) {
+            throw new NextcloudApiException(e);
+        } finally {
+            shutdownSardine(sardine);
+        }
+    }
+
+    private static boolean toBoolean(String value) {
+        return "true".equalsIgnoreCase(value) || "1".equals(value);
+    }
+
+    private String authorizationHeader() {
+        if (getServerConfig().getAuthenticationConfig().usesBasicAuthentication()) {
+            String credentials = getServerConfig().getUserName() + ":"
+                    + getServerConfig().getAuthenticationConfig().getPassword();
+            return "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+        }
+        return "Bearer " + getServerConfig().getAuthenticationConfig().getBearerToken();
+    }
+
+    private CloseableHttpClient buildSyncClient() {
+        HttpClientBuilder builder = HttpClients.custom();
+        SSLContext sslContext = SslUtils.buildSslContext(getServerConfig());
+        if (sslContext != null) {
+            builder.setSSLContext(sslContext);
+            if (SslUtils.isHostnameVerificationDisabled(getServerConfig())) {
+                builder.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+            }
+        }
+        return builder.build();
+    }
+
+    private void shutdownSardine(Sardine sardine) {
+        try {
+            sardine.shutdown();
+        } catch (IOException e) {
+            // best effort
+        }
+    }
+}

--- a/src/main/java/org/aarboard/nextcloud/api/systemtags/SystemTags.java
+++ b/src/main/java/org/aarboard/nextcloud/api/systemtags/SystemTags.java
@@ -59,11 +59,11 @@ public class SystemTags extends AWebdavHandler {
     private static final String SYSTEMTAGS_RELATIONS = "remote.php/dav/systemtags-relations/files/";
     private static final String NS_OC = "http://owncloud.org/ns";
 
-    private static final QName PROP_ID = new QName(NS_OC, "id");
-    private static final QName PROP_DISPLAY_NAME = new QName(NS_OC, "display-name");
-    private static final QName PROP_USER_VISIBLE = new QName(NS_OC, "user-visible");
-    private static final QName PROP_USER_ASSIGNABLE = new QName(NS_OC, "user-assignable");
-    private static final QName PROP_CAN_ASSIGN = new QName(NS_OC, "can-assign");
+    private static final QName PROP_ID = new QName(NS_OC, "id", "oc");
+    private static final QName PROP_DISPLAY_NAME = new QName(NS_OC, "display-name", "oc");
+    private static final QName PROP_USER_VISIBLE = new QName(NS_OC, "user-visible", "oc");
+    private static final QName PROP_USER_ASSIGNABLE = new QName(NS_OC, "user-assignable", "oc");
+    private static final QName PROP_CAN_ASSIGN = new QName(NS_OC, "can-assign", "oc");
 
     public SystemTags(ServerConfig serverConfig) {
         super(serverConfig);

--- a/src/main/java/org/aarboard/nextcloud/api/systemtags/Tag.java
+++ b/src/main/java/org/aarboard/nextcloud/api/systemtags/Tag.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 a.schild
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.aarboard.nextcloud.api.systemtags;
+
+/**
+ * A Nextcloud system tag.
+ *
+ * @author a.schild
+ */
+public class Tag {
+
+    private int id;
+    private String name;
+    private boolean userVisible;
+    private boolean userAssignable;
+    private boolean canAssign;
+
+    public Tag() {
+    }
+
+    public Tag(int id, String name, boolean userVisible, boolean userAssignable, boolean canAssign) {
+        this.id = id;
+        this.name = name;
+        this.userVisible = userVisible;
+        this.userAssignable = userAssignable;
+        this.canAssign = canAssign;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isUserVisible() {
+        return userVisible;
+    }
+
+    public void setUserVisible(boolean userVisible) {
+        this.userVisible = userVisible;
+    }
+
+    public boolean isUserAssignable() {
+        return userAssignable;
+    }
+
+    public void setUserAssignable(boolean userAssignable) {
+        this.userAssignable = userAssignable;
+    }
+
+    public boolean isCanAssign() {
+        return canAssign;
+    }
+
+    public void setCanAssign(boolean canAssign) {
+        this.canAssign = canAssign;
+    }
+}

--- a/src/main/java/org/aarboard/nextcloud/api/webdav/AWebdavHandler.java
+++ b/src/main/java/org/aarboard/nextcloud/api/webdav/AWebdavHandler.java
@@ -162,6 +162,35 @@ public abstract class AWebdavHandler
         return uB.toString();
     }
 
+    /**
+     * Builds the full URL for an arbitrary DAV path (not the user's files root),
+     * e.g. the system tags endpoints.
+     *
+     * @param davPath path below the host, without a leading slash
+     *                (e.g. {@code remote.php/dav/systemtags/})
+     * @return the full URL including scheme, host and port
+     */
+    protected String buildDavUrl(String davPath)
+    {
+        String path = this.serverConfig.getSubPathPrefix() != null
+                ? "/" + this.serverConfig.getSubPathPrefix() + "/" + davPath
+                : "/" + davPath;
+        URIBuilder uB = new URIBuilder()
+                .setScheme(this.serverConfig.isUseHTTPS() ? "https" : "http")
+                .setHost(this.serverConfig.getServerName())
+                .setPort(this.serverConfig.getPort())
+                .setPath(path);
+        return uB.toString();
+    }
+
+    /**
+     * @return the server configuration backing this handler
+     */
+    protected ServerConfig getServerConfig()
+    {
+        return this.serverConfig;
+    }
+
     protected String getWebdavPathPrefix()
     {
         if (resolver != null)

--- a/src/test/java/org/aarboard/nextcloud/api/TestSystemTags.java
+++ b/src/test/java/org/aarboard/nextcloud/api/TestSystemTags.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 a.schild
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.aarboard.nextcloud.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.aarboard.nextcloud.api.systemtags.Tag;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+/**
+ * Integration tests for the system tags support.
+ *
+ * @author a.schild
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class TestSystemTags {
+
+    private static final String TEST_FOLDER = "/systemtags-test-folder";
+    private static final String TAG_NAME = "api-test-tag";
+
+    private static String serverName = null;
+    private static NextcloudConnector _nc = null;
+
+    private static int tagId = -1;
+    private static long fileId = -1;
+
+    @BeforeClass
+    public static void setUp() {
+        TestHelper th = new TestHelper();
+        serverName = th.getServerName();
+        if (serverName != null) {
+            _nc = new NextcloudConnector(serverName, th.getServerPort() == 443, th.getServerPort(),
+                    th.getUserName(), th.getPassword());
+            _nc.createFolder(TEST_FOLDER);
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (_nc != null) {
+            try {
+                if (tagId != -1) {
+                    _nc.deleteSystemTag(tagId);
+                }
+            } catch (Exception ex) {
+                // best effort
+            }
+            _nc.deleteFolder(TEST_FOLDER);
+        }
+    }
+
+    @Test
+    public void t01_testCreateTag() {
+        if (_nc != null) {
+            tagId = _nc.createSystemTag(TAG_NAME, true, true);
+            assertTrue(tagId > 0);
+        }
+    }
+
+    @Test
+    public void t02_testGetTags() {
+        if (_nc != null) {
+            assertTrue(_nc.getSystemTags().stream().anyMatch(t -> t.getId() == tagId));
+        }
+    }
+
+    @Test
+    public void t03_testAssignTag() throws Exception {
+        if (_nc != null) {
+            fileId = Long.parseLong(_nc.getProperties(TEST_FOLDER, true).getFileId());
+            _nc.assignSystemTag(fileId, tagId);
+
+            Tag assigned = _nc.getSystemTagsForFile(fileId).stream()
+                    .filter(t -> t.getId() == tagId).findFirst().orElse(null);
+            assertNotNull(assigned);
+            assertEquals(TAG_NAME, assigned.getName());
+        }
+    }
+
+    @Test
+    public void t04_testRemoveTag() {
+        if (_nc != null) {
+            _nc.removeSystemTag(fileId, tagId);
+            assertTrue(_nc.getSystemTagsForFile(fileId).stream().noneMatch(t -> t.getId() == tagId));
+        }
+    }
+
+    @Test
+    public void t05_testDeleteTag() {
+        if (_nc != null) {
+            int deletedId = tagId;
+            _nc.deleteSystemTag(tagId);
+            tagId = -1;
+            assertTrue(_nc.getSystemTags().stream().noneMatch(t -> t.getId() == deletedId));
+        }
+    }
+}


### PR DESCRIPTION
Implements #110: Nextcloud system tags.

## Added
- New `org.aarboard.nextcloud.api.systemtags` package with a `SystemTags` connector (extends `AWebdavHandler`, reusing its auth + TLS Sardine): `getTags`, `getTagsForFile(fileId)`, `createTag(name, userVisible, userAssignable)`, `deleteTag(tagId)`, `assignTag(fileId, tagId)`, `removeTag(fileId, tagId)`.
- Uses the WebDAV `systemtags` / `systemtags-relations/files` endpoints (PROPFIND for listing via Sardine custom props, PUT/DELETE for relations, and a JSON POST for tag creation).
- `NextcloudConnector` facade methods (`getSystemTags`, `createSystemTag`, `assignSystemTag`, ...). File ids come from the existing `getProperties(path, true).getFileId()`.

## Testing
- `TestSystemTags` exercises the full lifecycle (create -> list -> assign to a folder -> list on file -> remove -> delete). System tags are core (no app install needed).
- Validated by this PR CI run.

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)