### PR TITLE
Reference-count connector lifecycle (#87)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 # Changelog for nextcloud api
 
 ## Version 14.2.0
+- Fix connector lifecycle: closing a `NextcloudConnector` now shuts down the
+  shared HTTP client only once the last open connector is closed, so closing
+  one connector no longer breaks others still in use (issue #87). Use
+  `shutdown()` to force an immediate teardown.
 - Add system tags support: list, create and delete system tags, and assign or
   remove tags on a file via the new `SystemTags` connector and
   `NextcloudConnector` methods (issue #110)

--- a/src/main/java/org/aarboard/nextcloud/api/NextcloudConnector.java
+++ b/src/main/java/org/aarboard/nextcloud/api/NextcloudConnector.java
@@ -49,6 +49,15 @@ import org.aarboard.nextcloud.api.webdav.pathresolver.WebDavPathResolverBuilder;
 
 public class NextcloudConnector implements AutoCloseable {
 
+    /**
+     * Number of open connectors sharing the static HTTP client, so it is only
+     * shut down once the last connector is closed (see issue #87).
+     */
+    private static final java.util.concurrent.atomic.AtomicInteger OPEN_INSTANCES =
+            new java.util.concurrent.atomic.AtomicInteger(0);
+
+    private volatile boolean closed = false;
+
     private final ServerConfig serverConfig;
     private final ProvisionConnector pc;
     private final FilesharingConnector fc;
@@ -121,6 +130,7 @@ public class NextcloudConnector implements AutoCloseable {
             fl = new Files(this.serverConfig);
             gf = new GroupFolders(this.serverConfig);
             st = new SystemTags(this.serverConfig);
+            OPEN_INSTANCES.incrementAndGet();
 
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException(e);
@@ -144,6 +154,7 @@ public class NextcloudConnector implements AutoCloseable {
         fl = new Files(this.serverConfig);
         gf = new GroupFolders(this.serverConfig);
         st = new SystemTags(this.serverConfig);
+        OPEN_INSTANCES.incrementAndGet();
     }
 
     /**
@@ -193,8 +204,11 @@ public class NextcloudConnector implements AutoCloseable {
     }
 
     /**
-     * Close the HTTP client. Perform this to cleanly shut down this
-     * application.
+     * Immediately shuts down the shared HTTP client, regardless of how many
+     * other {@link NextcloudConnector} instances are still open. Prefer
+     * {@link #close()} (e.g. via try-with-resources), which only shuts the
+     * shared client down once the last connector is closed. Use this only when
+     * you explicitly want to tear everything down at once.
      *
      * @throws IOException In case of IO errors
      */
@@ -401,13 +415,22 @@ public class NextcloudConnector implements AutoCloseable {
     }
 
     /**
-     * Close the HTTP client. Perform this to cleanly shut down this
-     * application.
+     * Closes this connector. The shared HTTP client is only shut down once the
+     * last open {@link NextcloudConnector} has been closed, so closing one
+     * connector no longer breaks others that are still in use (see issue #87).
+     * Idempotent: closing an already-closed connector does nothing.
      *
      * @throws Exception In case of errors
      */
+    @Override
     public void close() throws Exception {
-        shutdown();
+        if (closed) {
+            return;
+        }
+        closed = true;
+        if (OPEN_INSTANCES.decrementAndGet() <= 0) {
+            shutdown();
+        }
     }
 
     /**

--- a/src/test/java/org/aarboard/nextcloud/api/TestConnectorLifecycle.java
+++ b/src/test/java/org/aarboard/nextcloud/api/TestConnectorLifecycle.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 a.schild
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.aarboard.nextcloud.api;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+/**
+ * Verifies the shared-HTTP-client lifecycle: closing one connector must not
+ * shut the shared client down while another connector is still in use
+ * (issue #87).
+ *
+ * @author a.schild
+ */
+public class TestConnectorLifecycle {
+
+    @Test
+    public void testClosingOneConnectorDoesNotBreakAnother() throws Exception {
+        TestHelper th = new TestHelper();
+        String serverName = th.getServerName();
+        if (serverName == null) {
+            return;
+        }
+        NextcloudConnector first = newConnector(th);
+        NextcloudConnector second = newConnector(th);
+        try {
+            assertNotNull(first.getShares());
+            assertNotNull(second.getShares());
+
+            // Closing the first connector must not tear down the shared client
+            // that the second one still relies on.
+            first.close();
+
+            assertNotNull(second.getShares());
+        } finally {
+            second.close();
+        }
+    }
+
+    private NextcloudConnector newConnector(TestHelper th) {
+        return new NextcloudConnector(th.getServerName(), th.getServerPort() == 443,
+                th.getServerPort(), th.getUserName(), th.getPassword());
+    }
+}


### PR DESCRIPTION
Fixes #87.

## Problem
`NextcloudConnector.close()` shut down the static, shared HTTP client. With multiple connectors alive, closing one broke the others.

## Fix
- Track the number of open `NextcloudConnector` instances; `close()` shuts the shared client down only when the **last** connector is closed. `close()` is now idempotent.
- `shutdown()` still forces an immediate teardown for callers who want it.

## Test
`TestConnectorLifecycle` opens two connectors, closes the first, and asserts the second still works - this fails before the fix (the shared client was torn down) and passes after.

Note: direct users of the individual connectors (e.g. `FilesharingConnector`) are not counted; they manage teardown via `ConnectorCommon.shutdown()` as before.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)